### PR TITLE
Added a function that will replace the httpBackend.Client on a Collec…

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -19,6 +19,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/urlfetch"
+
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/charset"
 
@@ -168,6 +171,20 @@ func (c *Collector) Init() {
 	c.lock = &sync.RWMutex{}
 	c.robotsMap = make(map[string]*robotstxt.RobotsData, 0)
 	c.IgnoreRobotsTxt = true
+}
+
+// Appengine will replace the Collector's backend http.Client
+// With an Http.Client that is provided by appengine/urlfetch
+// This function should be used when the scraper is initiated
+// by a http.Request to Google App Engine
+func (c *Collector) Appengine(req *http.Request) {
+	ctx := appengine.NewContext(req)
+	client := urlfetch.Client(ctx)
+	client.Jar = c.backend.Client.Jar
+	client.CheckRedirect = c.backend.Client.CheckRedirect
+	client.Timeout = c.backend.Client.Timeout
+
+	c.backend.Client = client
 }
 
 // Visit starts Collector's collecting job by creating a


### PR DESCRIPTION
Currently Colly would only work in Google App Engine in the flexible environment due to restrictions placed on the standard environment with regards to outbound HTTP requests.

By replacing the Http Client, that is attached to the Collector when the Collector is initialized, with a Http Client that is provided by the appengine/urlfetch package, scrapers written with Colly can be used in the App Engine standard environment.

Should be used as follows:

```
func startScraper(w http.ResponseWriter, r *http.Request) {
  c := colly.NewCollector()
  c.Appengine(r)
   ...
  c.Visit("https://google.ca")
}
```

Thanks,

schmorrison