### PR TITLE
NewHTMLElementFromSelectionNode implementation

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -128,6 +128,18 @@ type HTMLElement struct {
 	DOM *goquery.Selection
 }
 
+// NewHTMLElementFromSelectionNode creates a HTMLElement from a goquery.Selection Node.
+func NewHTMLElementFromSelectionNode(resp *Response, s *goquery.Selection, n *html.Node) *HTMLElement {
+	return &HTMLElement{
+		Name:       n.Data,
+		Request:    resp.Request,
+		Response:   resp,
+		Text:       goquery.NewDocumentFromNode(n).Text(),
+		DOM:        s,
+		attributes: n.Attr,
+	}
+}
+
 // Context provides a tiny layer for passing data between callbacks
 type Context struct {
 	contextMap map[string]interface{}
@@ -599,14 +611,7 @@ func (c *Collector) handleOnHTML(resp *Response) {
 	for _, cc := range c.htmlCallbacks {
 		doc.Find(cc.Selector).Each(func(i int, s *goquery.Selection) {
 			for _, n := range s.Nodes {
-				e := &HTMLElement{
-					Name:       n.Data,
-					Request:    resp.Request,
-					Response:   resp,
-					Text:       goquery.NewDocumentFromNode(n).Text(),
-					DOM:        s,
-					attributes: n.Attr,
-				}
+				e := NewHTMLElementFromSelectionNode(resp, s, n)
 				if c.debugger != nil {
 					c.debugger.Event(createEvent("html", resp.Request.Id, c.Id, map[string]string{
 						"selector": cc.Selector,

--- a/colly_test.go
+++ b/colly_test.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"net/http"
 	"testing"
+
+	"github.com/PuerkitoBio/goquery"
 )
 
 var testServerPort int = 31337
@@ -294,4 +296,41 @@ func TestIgnoreRobotsWhenDisallowed(t *testing.T) {
 		t.Fatal(err)
 	}
 
+}
+
+func TestHTMLElement(t *testing.T) {
+	ctx := &Context{}
+	resp := &Response{
+		Request: &Request{
+			Ctx: ctx,
+		},
+		Ctx: ctx,
+	}
+
+	in := `<a href="http://go-colly.org">Colly</a>`
+	sel := "a[href]"
+	doc, err := goquery.NewDocumentFromReader(bytes.NewBuffer([]byte(in)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	elements := []*HTMLElement{}
+	doc.Find(sel).Each(func(i int, s *goquery.Selection) {
+		for _, n := range s.Nodes {
+			elements = append(elements, NewHTMLElementFromSelectionNode(resp, s, n))
+		}
+	})
+	len_elements := len(elements)
+	if len_elements != 1 {
+		t.Errorf("element lenght mismatch. got %d, expected %d.\n", len_elements, 1)
+	}
+	v := elements[0]
+	if v.Name != "a" {
+		t.Errorf("element tag mismatch. got %s, expected %s.\n", v.Name, "a")
+	}
+	if v.Text != "Colly" {
+		t.Errorf("element content mismatch. got %s, expected %s.\n", v.Text, "Colly")
+	}
+	if v.Attr("href") != "http://go-colly.org" {
+		t.Errorf("element href mismatch. got %s, expected %s.\n", v.Attr("href"), "http://go-colly.org")
+	}
 }


### PR DESCRIPTION
Case scenario: Using HTMLElement in external package unittest

Problem: HTMLElement has local `attributes` that make impossible from other packages to instantiate a HTMLElement with values in attributes.

FIx: Implementation of NewHTMLElementFromSelectionNode