### PR TITLE
[fix] close file after checking error in http backend

### DIFF
--- a/http_backend.go
+++ b/http_backend.go
@@ -137,10 +137,10 @@ func (h *httpBackend) Cache(request *http.Request, bodySize int, cacheDir string
 		}
 	}
 	file, err := os.Create(filename + "~")
-	defer file.Close()
 	if err != nil {
 		return resp, err
 	}
+	defer file.Close()
 	if err := gob.NewEncoder(file).Encode(resp); err != nil {
 		return resp, err
 	}


### PR DESCRIPTION
If create returns error, file will be nil so panics. Defer moved after error check.