### PR TITLE
cacheDir Windows Bug

### DIFF
--- a/http_backend.go
+++ b/http_backend.go
@@ -140,6 +140,7 @@ func (h *httpBackend) Cache(request *http.Request, bodySize int, cacheDir string
 		return resp, err
 	}
 	if err := gob.NewEncoder(file).Encode(resp); err != nil {
+		file.Close()
 		return resp, err
 	}
 	file.Close()

--- a/http_backend.go
+++ b/http_backend.go
@@ -139,10 +139,10 @@ func (h *httpBackend) Cache(request *http.Request, bodySize int, cacheDir string
 	if err != nil {
 		return resp, err
 	}
-	defer file.Close()
 	if err := gob.NewEncoder(file).Encode(resp); err != nil {
 		return resp, err
 	}
+	file.Close()
 	return resp, os.Rename(filename+"~", filename)
 }
 


### PR DESCRIPTION
## Issue
Using CacheDir on Windows fails on the first visit and closes the scraper.

## Source
The cache file must be closed before os.Rename is called or it will cause the error "The process cannot access the file because it is being used by another process" on Windows.

## Fix
Rather than defer, we close the file intentionally after gob.Encode ensuring it is closed before os.Rename is called.