### PR TITLE
Introduces reddit example

### DIFF
--- a/_examples/reddit/reddit.go
+++ b/_examples/reddit/reddit.go
@@ -25,7 +25,7 @@ func main() {
 	)
 
 	// On every a element which has .top-matter attribute call callback
-  // This class is unique to the div that holds all information about a story
+	// This class is unique to the div that holds all information about a story
 	c.OnHTML(".top-matter", func(e *colly.HTMLElement) {
 		temp := item{}
 		temp.StoryURL = e.ChildAttr("a[data-event-action=title]", "href")
@@ -36,13 +36,13 @@ func main() {
 		stories = append(stories, temp)
 	})
 
-  // On every span tag with the class next-button
+	// On every span tag with the class next-button
 	c.OnHTML("span.next-button", func(h *colly.HTMLElement) {
 		t := h.ChildAttr("a", "href")
 		c.Visit(t)
 	})
 
-  // Set max Parallelism and introduce a Random Delay
+	// Set max Parallelism and introduce a Random Delay
 	c.Limit(&colly.LimitRule{
 		Parallelism: 2,
 		RandomDelay: 5 * time.Second,

--- a/_examples/reddit/reddit.go
+++ b/_examples/reddit/reddit.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gocolly/colly"
 )
 
-type Item struct {
+type item struct {
 	StoryURL  string
 	Source    string
 	comments  string
@@ -17,7 +17,7 @@ type Item struct {
 }
 
 func main() {
-	stories := []Item{}
+	stories := []item{}
 	// Instantiate default collector
 	c := colly.NewCollector(
 		// Visit only domains: reddit.com
@@ -27,7 +27,7 @@ func main() {
 	// On every a element which has .top-matter attribute call callback
   // This class is unique to the div that holds all information about a story
 	c.OnHTML(".top-matter", func(e *colly.HTMLElement) {
-		temp := models.Item{}
+		temp := item{}
 		temp.StoryURL = e.ChildAttr("a[data-event-action=title]", "href")
 		temp.Source = "https://www.reddit.com/r/programming/"
 		temp.Title = e.ChildText("a[data-event-action=title]")

--- a/_examples/reddit/reddit.go
+++ b/_examples/reddit/reddit.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gocolly/colly"
+)
+
+type Item struct {
+	StoryURL  string
+	Source    string
+	comments  string
+	CrawledAt time.Time
+	Comments  string
+	Title     string
+}
+
+func main() {
+	stories := []Item{}
+	// Instantiate default collector
+	c := colly.NewCollector(
+		// Visit only domains: reddit.com
+		colly.AllowedDomains("www.reddit.com"),
+	)
+
+	// On every a element which has .top-matter attribute call callback
+  // This class is unique to the div that holds all information about a story
+	c.OnHTML(".top-matter", func(e *colly.HTMLElement) {
+		temp := models.Item{}
+		temp.StoryURL = e.ChildAttr("a[data-event-action=title]", "href")
+		temp.Source = "https://www.reddit.com/r/programming/"
+		temp.Title = e.ChildText("a[data-event-action=title]")
+		temp.Comments = e.ChildAttr("a[data-event-action=comments]", "href")
+		temp.CrawledAt = time.Now()
+		stories = append(stories, temp)
+	})
+
+  // On every span tag with the class next-button
+	c.OnHTML("span.next-button", func(h *colly.HTMLElement) {
+		t := h.ChildAttr("a", "href")
+		c.Visit(t)
+	})
+
+  // Set max Parallelism and introduce a Random Delay
+	c.Limit(&colly.LimitRule{
+		Parallelism: 2,
+		RandomDelay: 5 * time.Second,
+	})
+
+	// Before making a request print "Visiting ..."
+	c.OnRequest(func(r *colly.Request) {
+		fmt.Println("Visiting", r.URL.String())
+
+	})
+	c.Visit("https://www.reddit.com/r/programming/")
+	c.Wait()
+	fmt.Println(stories)
+
+}

--- a/_examples/reddit/reddit.go
+++ b/_examples/reddit/reddit.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/gocolly/colly"
@@ -22,6 +23,7 @@ func main() {
 	c := colly.NewCollector(
 		// Visit only domains: reddit.com
 		colly.AllowedDomains("www.reddit.com"),
+		colly.Async(true),
 	)
 
 	// On every a element which has .top-matter attribute call callback
@@ -53,7 +55,14 @@ func main() {
 		fmt.Println("Visiting", r.URL.String())
 
 	})
-	c.Visit("https://www.reddit.com/r/programming/")
+
+	// Crawl all reddits the user passes in
+	reddits := os.Args[1:]
+	for _, reddit := range reddits {
+		c.Visit(reddit)
+
+	}
+
 	c.Wait()
 	fmt.Println(stories)
 


### PR DESCRIPTION
This pull request introduces an example for calling reddit.com/r/programming

This code has some interesting features.  

- It does some random time delaying
- Limits the parallelism
- Creates a generic struct to store crawl information
- Returns a mass splice with all stored crawl information at end of crawl
- Hits up the next page element to crawl the next page (if there are more) for more information!

I would appreciate if this example was introduced into the code-base!

If there are any critiques or changes needed to get it in please let me know!
