### PR TITLE
Connection error when getting robots.txt leads to runtime error

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -565,9 +565,6 @@ func (c *Collector) isDomainAllowed(domain string) bool {
 }
 
 func (c *Collector) checkRobots(u *url.URL) error {
-	// var robot *robotstxt.RobotsData
-	// var ok bool
-
 	c.lock.RLock()
 	robot, ok := c.robotsMap[u.Host]
 	c.lock.RUnlock()

--- a/colly.go
+++ b/colly.go
@@ -567,7 +567,6 @@ func (c *Collector) isDomainAllowed(domain string) bool {
 func (c *Collector) checkRobots(u *url.URL) error {
 	// var robot *robotstxt.RobotsData
 	// var ok bool
-	var err error
 
 	c.lock.RLock()
 	robot, ok := c.robotsMap[u.Host]
@@ -575,7 +574,10 @@ func (c *Collector) checkRobots(u *url.URL) error {
 
 	if !ok {
 		// no robots file cached
-		resp, _ := c.backend.Client.Get(u.Scheme + "://" + u.Host + "/robots.txt")
+		resp, err := c.backend.Client.Get(u.Scheme + "://" + u.Host + "/robots.txt")
+		if err != nil {
+			return err
+		}
 		robot, err = robotstxt.FromResponse(resp)
 		if err != nil {
 			return err

--- a/colly_test.go
+++ b/colly_test.go
@@ -544,6 +544,19 @@ func TestIgnoreRobotsWhenDisallowed(t *testing.T) {
 
 }
 
+func TestConnectionErrorOnRobotsTxtResultsInError(t *testing.T) {
+	ts := newTestServer()
+	ts.Close() // immediately close the server to force a connection error
+
+	c := NewCollector()
+	c.IgnoreRobotsTxt = false
+	err := c.Visit(ts.URL)
+
+	if err == nil {
+		t.Fatal("Error expected")
+	}
+}
+
 func TestEnvSettings(t *testing.T) {
 	ts := newTestServer()
 	defer ts.Close()


### PR DESCRIPTION
I've added an explicit check for the error from the GET request and a simple test case for it.
Previously, the code ignored the error returned from the GET request. `resp` would then be `nil` in which case `robotstxt.FromResponse(resp)` returns `(nil,nil)` which would cause the runtime error a bit later in `robot.FindGroup(c.UserAgent)`.