### PR TITLE
Add support to URL regexp blacklisting

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -278,7 +278,7 @@ func DisallowedDomains(domains ...string) func(*Collector) {
 	}
 }
 
-// DisallowdURLFilters sets the list of regular expressions which restricts
+// DisallowedURLFilters sets the list of regular expressions which restricts
 // visiting URLs. If any of the rules matches to a URL the request will be stopped.
 func DisallowedURLFilters(filters ...*regexp.Regexp) func(*Collector) {
 	return func(c *Collector) {

--- a/colly_test.go
+++ b/colly_test.go
@@ -193,6 +193,17 @@ var newCollectorTests = map[string]func(*testing.T){
 			}
 		}
 	},
+	"DisallowedURLFilters": func(t *testing.T) {
+		for _, filters := range [][]*regexp.Regexp{
+			{regexp.MustCompile(`.*not_allowed.*`)},
+		} {
+			c := NewCollector(DisallowedURLFilters(filters...))
+
+			if got, want := c.DisallowedURLFilters, filters; !reflect.DeepEqual(got, want) {
+				t.Fatalf("c.DisallowedURLFilters = %v, want %v", got, want)
+			}
+		}
+	},
 	"URLFilters": func(t *testing.T) {
 		for _, filters := range [][]*regexp.Regexp{
 			{regexp.MustCompile(`\w+`)},


### PR DESCRIPTION
Now it is possible to define some regexp to blacklist some URL patterns.
For example:
```
package main

import (
	"github.com/OSPG/colly"
	"log"
	"regexp"
)

func main() {
	r := regexp.MustCompile(`https://.*debian\.org/?.*`)
	r2 := regexp.MustCompile(`(png|jpg|jpeg|gif|ico|pdf|iso)$`)
	c := colly.NewCollector(
		colly.URLFilters(r),
		colly.DisallowedURLFilters(r2),
	)
	c.OnHTML("a", func(e *colly.HTMLElement) {
		link := e.Request.AbsoluteURL(e.Attr("href"))
		if len(link) > 0 {
			//		    log.Println("I'm going to try to visit", link)
			c.Visit(link)
		}

	})
	c.OnRequest(func(r *colly.Request) {
		log.Println("visiting", r.URL.String())
	})
	log.Println(c.DisallowedURLFilters)
	c.Visit("https://debian.org")
}
```

It will not visit any that matches with `(png|jpg|jpeg|gif|ico|pdf|iso)$`