### PR TITLE
Convert http_backend to an interface

### DIFF
--- a/_examples/instagram/instagram.go
+++ b/_examples/instagram/instagram.go
@@ -19,7 +19,7 @@ const instagramQueryId = "42323d64886122307be10013ad2dcc45"
 
 // "id": user id, "after": end cursor
 const nextPageURL string = `https://www.instagram.com/graphql/query/?query_hash=%s&variables=%s`
-const nextPagePayload string = `{"id":"%s","first":12,"after":"%s"}`
+const nextPagePayload string = `{"id":"%s","first":50,"after":"%s"}`
 
 var requestID string
 

--- a/_examples/local_files/html/child_page/one.html
+++ b/_examples/local_files/html/child_page/one.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <h1>Child Page One</h1>
+</body>
+</html>

--- a/_examples/local_files/html/child_page/three.html
+++ b/_examples/local_files/html/child_page/three.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <h1>Child Page Three</h1>
+</body>
+</html>

--- a/_examples/local_files/html/child_page/two.html
+++ b/_examples/local_files/html/child_page/two.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <h1>Child Page Two</h1>
+</body>
+</html>

--- a/_examples/local_files/html/index.html
+++ b/_examples/local_files/html/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <h1>Index.html</h1>
+    <ul>
+        <li><a href="/child_page/one.html"></a></li>
+        <li><a href="/child_page/two.html"></a></li>
+        <li><a href="/child_page/three.html"></a></li>
+    </ul>
+</body>
+</html>

--- a/_examples/local_files/local_files.go
+++ b/_examples/local_files/local_files.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gocolly/colly"
+)
+
+func main() {
+	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		panic(err)
+	}
+
+	t := &http.Transport{}
+	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
+
+	c := colly.NewCollector()
+	c.WithTransport(t)
+
+	pages := []string{}
+
+	c.OnHTML("h1", func(e *colly.HTMLElement) {
+		pages = append(pages, e.Text)
+	})
+
+	c.OnHTML("a", func(e *colly.HTMLElement) {
+		c.Visit("file://" + dir + "/html" + e.Attr("href"))
+	})
+
+	fmt.Println("file://" + dir + "/html/index.html")
+	c.Visit("file://" + dir + "/html/index.html")
+	c.Wait()
+	for i, p := range pages {
+		fmt.Printf("%d : %s\n", i, p)
+	}
+}

--- a/appengine_backend.go
+++ b/appengine_backend.go
@@ -103,14 +103,14 @@ func (h *appEngineBackend) Cache(request *http.Request, bodySize int, cacheDir s
 func (h *appEngineBackend) Do(request *http.Request, bodySize int) (*Response, error) {
 	r := h.GetMatchingRule(request.URL.Host)
 	if r != nil {
-		r.waitChan <- true
+		r.WaitChan <- true
 		defer func(r *LimitRule) {
 			randomDelay := time.Duration(0)
 			if r.RandomDelay != 0 {
 				randomDelay = time.Duration(rand.Intn(int(r.RandomDelay)))
 			}
 			time.Sleep(r.Delay + randomDelay)
-			<-r.waitChan
+			<-r.WaitChan
 		}(r)
 	}
 

--- a/appengine_backend.go
+++ b/appengine_backend.go
@@ -1,0 +1,207 @@
+// Copyright 2018 Adam Tauber
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package colly
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/gob"
+	"encoding/hex"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"sync"
+	"time"
+
+	"google.golang.org/appengine/urlfetch"
+)
+
+type appEngineBackend struct {
+	LimitRules []*LimitRule
+	Client     *http.Client
+	lock       *sync.RWMutex
+}
+
+func (h *appEngineBackend) Init(jar http.CookieJar) {
+	rand.Seed(time.Now().UnixNano())
+
+	ctx := context.Background()
+	h.Client = urlfetch.Client(ctx)
+	h.Client.Jar = jar
+	h.Client.Timeout = 10 * time.Second
+
+	h.lock = &sync.RWMutex{}
+}
+
+func (h *appEngineBackend) GetMatchingRule(domain string) *LimitRule {
+	if h.LimitRules == nil {
+		return nil
+	}
+	h.lock.RLock()
+	defer h.lock.RUnlock()
+	for _, r := range h.LimitRules {
+		if r.Match(domain) {
+			return r
+		}
+	}
+	return nil
+}
+
+func (h *appEngineBackend) Cache(request *http.Request, bodySize int, cacheDir string) (*Response, error) {
+	if cacheDir == "" || request.Method != "GET" {
+		return h.Do(request, bodySize)
+	}
+	sum := sha1.Sum([]byte(request.URL.String()))
+	hash := hex.EncodeToString(sum[:])
+	dir := path.Join(cacheDir, hash[:2])
+	filename := path.Join(dir, hash)
+	if file, err := os.Open(filename); err == nil {
+		resp := new(Response)
+		err := gob.NewDecoder(file).Decode(resp)
+		file.Close()
+		if resp.StatusCode < 500 {
+			return resp, err
+		}
+	}
+	resp, err := h.Do(request, bodySize)
+	if err != nil || resp.StatusCode >= 500 {
+		return resp, err
+	}
+	if _, err := os.Stat(dir); err != nil {
+		if err := os.MkdirAll(dir, 0750); err != nil {
+			return resp, err
+		}
+	}
+	file, err := os.Create(filename + "~")
+	if err != nil {
+		return resp, err
+	}
+	if err := gob.NewEncoder(file).Encode(resp); err != nil {
+		file.Close()
+		return resp, err
+	}
+	file.Close()
+	return resp, os.Rename(filename+"~", filename)
+}
+
+func (h *appEngineBackend) Do(request *http.Request, bodySize int) (*Response, error) {
+	r := h.GetMatchingRule(request.URL.Host)
+	if r != nil {
+		r.waitChan <- true
+		defer func(r *LimitRule) {
+			randomDelay := time.Duration(0)
+			if r.RandomDelay != 0 {
+				randomDelay = time.Duration(rand.Intn(int(r.RandomDelay)))
+			}
+			time.Sleep(r.Delay + randomDelay)
+			<-r.waitChan
+		}(r)
+	}
+
+	res, err := h.Client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	*request = *res.Request
+
+	var bodyReader io.Reader = res.Body
+	if bodySize > 0 {
+		bodyReader = io.LimitReader(bodyReader, int64(bodySize))
+	}
+	body, err := ioutil.ReadAll(bodyReader)
+	defer res.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	return &Response{
+		StatusCode: res.StatusCode,
+		Body:       body,
+		Headers:    &res.Header,
+	}, nil
+}
+
+func (h *appEngineBackend) Limit(rule *LimitRule) error {
+	h.lock.Lock()
+	if h.LimitRules == nil {
+		h.LimitRules = make([]*LimitRule, 0, 8)
+	}
+	h.LimitRules = append(h.LimitRules, rule)
+	h.lock.Unlock()
+	return rule.Init()
+}
+
+func (h *appEngineBackend) Limits(rules []*LimitRule) error {
+	for _, r := range rules {
+		if err := h.Limit(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *appEngineBackend) Jar(j http.CookieJar) {
+	h.Client.Jar = j
+}
+
+func (h *appEngineBackend) GetJar() http.CookieJar {
+	return h.Client.Jar
+}
+
+func (h *appEngineBackend) Transport(t http.RoundTripper) {
+	h.Client.Transport = t
+}
+
+func (h *appEngineBackend) Timeout(t time.Duration) {
+	h.Client.Timeout = t
+}
+
+func (h *appEngineBackend) GetTimeout() time.Duration {
+	return h.Client.Timeout
+}
+
+func (h *appEngineBackend) Proxy(pf ProxyFunc) {
+	t, ok := h.Client.Transport.(*http.Transport)
+	if h.Client.Transport != nil && ok {
+		t.Proxy = pf
+	} else {
+		h.Client.Transport = &http.Transport{
+			Proxy: pf,
+		}
+	}
+}
+
+func (h *appEngineBackend) SetCookies(url *url.URL, cookies []*http.Cookie) error {
+	if h.Client.Jar == nil {
+		return ErrNoCookieJar
+	}
+	h.Client.Jar.SetCookies(url, cookies)
+	return nil
+}
+
+func (h *appEngineBackend) Cookies(url *url.URL) []*http.Cookie {
+	if h.Client.Jar == nil {
+		return nil
+	}
+
+	return h.Client.Jar.Cookies(url)
+}
+
+func (h *appEngineBackend) CheckRedirect(f func(req *http.Request, via []*http.Request) error) {
+	h.Client.CheckRedirect = f
+}

--- a/colly.go
+++ b/colly.go
@@ -1102,7 +1102,7 @@ func (c *Collector) Clone() *Collector {
 		requestCallbacks:       make([]RequestCallback, 0, 8),
 		responseCallbacks:      make([]ResponseCallback, 0, 8),
 		robotsMap:              c.robotsMap,
-		wg:                     c.wg,
+		wg:                     &sync.WaitGroup{},
 	}
 }
 

--- a/colly.go
+++ b/colly.go
@@ -567,6 +567,11 @@ func (c *Collector) fetch(u, method string, depth int, requestData io.Reader, ct
 	if method == "POST" && req.Header.Get("Content-Type") == "" {
 		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	}
+
+	if req.Header.Get("Accept") == "" {
+		req.Header.Set("Accept", "*/*")
+	}
+
 	origURL := req.URL
 	response, err := c.backend.Cache(req, c.MaxBodySize, c.CacheDir)
 	if err := c.handleOnError(response, err, request, ctx); err != nil {

--- a/colly.go
+++ b/colly.go
@@ -459,7 +459,7 @@ func (c *Collector) UnmarshalRequest(r []byte) (*Request, error) {
 		Body:      bytes.NewReader(req.Body),
 		Ctx:       ctx,
 		ID:        atomic.AddUint32(&c.requestCount, 1),
-		Headers:   &http.Header{},
+		Headers:   &req.Headers,
 		collector: c,
 	}, nil
 }

--- a/colly.go
+++ b/colly.go
@@ -351,6 +351,17 @@ func Debugger(d debug.Debugger) func(*Collector) {
 	}
 }
 
+// Driver sets the HTTPDriver used by the Collector.
+func Driver(backend HTTPDriver) func(*Collector) {
+	return func(c *Collector) {
+		jar := c.backend.GetJar()
+		timeout := c.backend.GetTimeout()
+		c.backend = backend
+		c.backend.Init(jar)
+		c.backend.Timeout(timeout)
+	}
+}
+
 // Init initializes the Collector's private variables and sets default
 // configuration for the Collector
 func (c *Collector) Init() {

--- a/colly.go
+++ b/colly.go
@@ -38,8 +38,6 @@ import (
 	"time"
 
 	"golang.org/x/net/html"
-	"google.golang.org/appengine"
-	"google.golang.org/appengine/urlfetch"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/antchfx/htmlquery"
@@ -115,7 +113,7 @@ type Collector struct {
 	scrapedCallbacks  []ScrapedCallback
 	requestCount      uint32
 	responseCount     uint32
-	backend           *httpBackend
+	backend           HTTPDriver
 	wg                *sync.WaitGroup
 	lock              *sync.RWMutex
 }
@@ -194,7 +192,7 @@ var envMap = map[string]func(*Collector, string){
 		c.DetectCharset = isYesString(val)
 	},
 	"DISABLE_COOKIES": func(c *Collector, _ string) {
-		c.backend.Client.Jar = nil
+		c.backend.Jar(nil)
 	},
 	"DISALLOWED_DOMAINS": func(c *Collector, val string) {
 		c.DisallowedDomains = strings.Split(val, ",")
@@ -364,7 +362,7 @@ func (c *Collector) Init() {
 	c.backend = &httpBackend{}
 	jar, _ := cookiejar.New(nil)
 	c.backend.Init(jar)
-	c.backend.Client.CheckRedirect = c.checkRedirectFunc()
+	c.backend.CheckRedirect(c.checkRedirectFunc())
 	c.wg = &sync.WaitGroup{}
 	c.lock = &sync.RWMutex{}
 	c.robotsMap = make(map[string]*robotstxt.RobotsData)
@@ -377,13 +375,21 @@ func (c *Collector) Init() {
 // This function should be used when the scraper is initiated
 // by a http.Request to Google App Engine
 func (c *Collector) Appengine(req *http.Request) {
-	ctx := appengine.NewContext(req)
-	client := urlfetch.Client(ctx)
-	client.Jar = c.backend.Client.Jar
-	client.CheckRedirect = c.backend.Client.CheckRedirect
-	client.Timeout = c.backend.Client.Timeout
+	var jar http.CookieJar
+	var timeout time.Duration
 
-	c.backend.Client = client
+	if c.backend != nil {
+		jar = c.backend.GetJar()
+		timeout = c.backend.GetTimeout()
+	} else {
+		jar, _ = cookiejar.New(nil)
+		timeout = 10 * time.Second
+	}
+
+	c.backend = &appEngineBackend{}
+	c.backend.Init(jar)
+	c.backend.CheckRedirect(c.checkRedirectFunc())
+	c.backend.Timeout(timeout)
 }
 
 // Visit starts Collector's collecting job by creating a
@@ -664,11 +670,15 @@ func (c *Collector) checkRobots(u *url.URL) error {
 
 	if !ok {
 		// no robots file cached
-		resp, err := c.backend.Client.Get(u.Scheme + "://" + u.Host + "/robots.txt")
+		req, err := http.NewRequest("GET", u.Scheme+"://"+u.Host+"/robots.txt", nil)
 		if err != nil {
 			return err
 		}
-		robot, err = robotstxt.FromResponse(resp)
+		resp, err := c.backend.Do(req, 0)
+		if err != nil {
+			return err
+		}
+		robot, err = robotstxt.FromStatusAndBytes(resp.StatusCode, resp.Body)
 		if err != nil {
 			return err
 		}
@@ -814,22 +824,22 @@ func (c *Collector) OnScraped(f ScrapedCallback) {
 
 // WithTransport allows you to set a custom http.RoundTripper (transport)
 func (c *Collector) WithTransport(transport http.RoundTripper) {
-	c.backend.Client.Transport = transport
+	c.backend.Transport(transport)
 }
 
 // DisableCookies turns off cookie handling
 func (c *Collector) DisableCookies() {
-	c.backend.Client.Jar = nil
+	c.backend.Jar(nil)
 }
 
 // SetCookieJar overrides the previously set cookie jar
 func (c *Collector) SetCookieJar(j *cookiejar.Jar) {
-	c.backend.Client.Jar = j
+	c.backend.Jar(j)
 }
 
 // SetRequestTimeout overrides the default timeout (10 seconds) for this collector
 func (c *Collector) SetRequestTimeout(timeout time.Duration) {
-	c.backend.Client.Timeout = timeout
+	c.backend.Timeout(timeout)
 }
 
 // SetStorage overrides the default in-memory storage.
@@ -839,7 +849,7 @@ func (c *Collector) SetStorage(s storage.Storage) error {
 		return err
 	}
 	c.store = s
-	c.backend.Client.Jar = createJar(s)
+	c.backend.Jar(createJar(s))
 	return nil
 }
 
@@ -867,14 +877,7 @@ func (c *Collector) SetProxy(proxyURL string) error {
 // and "socks5" are supported. If the scheme is empty,
 // "http" is assumed.
 func (c *Collector) SetProxyFunc(p ProxyFunc) {
-	t, ok := c.backend.Client.Transport.(*http.Transport)
-	if c.backend.Client.Transport != nil && ok {
-		t.Proxy = p
-	} else {
-		c.backend.Client.Transport = &http.Transport{
-			Proxy: p,
-		}
-	}
+	c.backend.Proxy(p)
 }
 
 func createEvent(eventType string, requestID, collectorID uint32, kvargs map[string]string) *debug.Event {
@@ -1048,27 +1051,21 @@ func (c *Collector) Limits(rules []*LimitRule) error {
 
 // SetCookies handles the receipt of the cookies in a reply for the given URL
 func (c *Collector) SetCookies(URL string, cookies []*http.Cookie) error {
-	if c.backend.Client.Jar == nil {
-		return ErrNoCookieJar
-	}
 	u, err := url.Parse(URL)
 	if err != nil {
 		return err
 	}
-	c.backend.Client.Jar.SetCookies(u, cookies)
+	c.backend.SetCookies(u, cookies)
 	return nil
 }
 
 // Cookies returns the cookies to send in a request for the given URL.
 func (c *Collector) Cookies(URL string) []*http.Cookie {
-	if c.backend.Client.Jar == nil {
-		return nil
-	}
 	u, err := url.Parse(URL)
 	if err != nil {
 		return nil
 	}
-	return c.backend.Client.Jar.Cookies(u)
+	return c.backend.Cookies(u)
 }
 
 // Clone creates an exact copy of a Collector without callbacks.

--- a/htmlelement.go
+++ b/htmlelement.go
@@ -97,3 +97,21 @@ func (h *HTMLElement) ForEach(goquerySelector string, callback func(int, *HTMLEl
 		}
 	})
 }
+
+// ForEachWithBreak iterates over the elements matched by the first argument
+// and calls the callback function on every HTMLElement match.
+// It is identical to ForEach except that it is possible to break
+// out of the loop by returning false in the callback function. It returns the
+// current Selection object.
+func (h *HTMLElement) ForEachWithBreak(goquerySelector string, callback func(int, *HTMLElement) bool) {
+	i := 0
+	h.DOM.Find(goquerySelector).EachWithBreak(func(_ int, s *goquery.Selection) bool {
+		for _, n := range s.Nodes {
+			if callback(i, NewHTMLElementFromSelectionNode(h.Response, s, n)) {
+				return true
+			}
+			i++
+		}
+		return false
+	})
+}

--- a/http_backend.go
+++ b/http_backend.go
@@ -28,6 +28,8 @@ import (
 	"sync"
 	"time"
 
+	"compress/gzip"
+
 	"github.com/gobwas/glob"
 )
 
@@ -186,6 +188,12 @@ func (h *httpBackend) Do(request *http.Request, bodySize int) (*Response, error)
 	var bodyReader io.Reader = res.Body
 	if bodySize > 0 {
 		bodyReader = io.LimitReader(bodyReader, int64(bodySize))
+	}
+	if res.Uncompressed && res.Header.Get("Content-Encoding") == "gzip" {
+		bodyReader, err = gzip.NewReader(bodyReader)
+		if err != nil {
+			return nil, err
+		}
 	}
 	body, err := ioutil.ReadAll(bodyReader)
 	defer res.Body.Close()

--- a/http_backend.go
+++ b/http_backend.go
@@ -189,7 +189,7 @@ func (h *httpBackend) Do(request *http.Request, bodySize int) (*Response, error)
 	if bodySize > 0 {
 		bodyReader = io.LimitReader(bodyReader, int64(bodySize))
 	}
-	if res.Uncompressed && res.Header.Get("Content-Encoding") == "gzip" {
+	if !res.Uncompressed && res.Header.Get("Content-Encoding") == "gzip" {
 		bodyReader, err = gzip.NewReader(bodyReader)
 		if err != nil {
 			return nil, err

--- a/http_backend.go
+++ b/http_backend.go
@@ -179,7 +179,9 @@ func (h *httpBackend) Do(request *http.Request, bodySize int) (*Response, error)
 	if err != nil {
 		return nil, err
 	}
-	*request = *res.Request
+	if res.Request != nil {
+		*request = *res.Request
+	}
 
 	var bodyReader io.Reader = res.Body
 	if bodySize > 0 {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -136,7 +136,9 @@ func (q *Queue) Run(c *colly.Collector) error {
 						break
 					}
 				}
+				q.lock.Lock()
 				atomic.AddInt32(&q.activeThreadCount, 1)
+				q.lock.Unlock()
 				rb, err := q.storage.GetRequest()
 				if err != nil || rb == nil {
 					q.finish()

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -157,8 +157,8 @@ func (q *Queue) Run(c *colly.Collector) error {
 }
 
 func (q *Queue) finish() {
-	atomic.AddInt32(&q.activeThreadCount, -1)
 	q.lock.Lock()
+	q.activeThreadCount--
 	for _, c := range q.threadChans {
 		c <- stop
 	}
@@ -206,5 +206,7 @@ func (q *InMemoryQueueStorage) GetRequest() ([]byte, error) {
 
 // QueueSize implements Storage.QueueSize() function
 func (q *InMemoryQueueStorage) QueueSize() (int, error) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
 	return q.size, nil
 }

--- a/request.go
+++ b/request.go
@@ -164,12 +164,15 @@ func (r *Request) Marshal() ([]byte, error) {
 			return nil, err
 		}
 	}
-	return json.Marshal(&serializableRequest{
-		URL:     r.URL.String(),
-		Method:  r.Method,
-		Body:    body,
-		ID:      r.ID,
-		Ctx:     ctx,
-		Headers: *r.Headers,
-	})
+	sr := &serializableRequest{
+		URL:    r.URL.String(),
+		Method: r.Method,
+		Body:   body,
+		ID:     r.ID,
+		Ctx:    ctx,
+	}
+	if r.Headers != nil {
+		sr.Headers = *r.Headers
+	}
+	return json.Marshal(sr)
 }

--- a/request.go
+++ b/request.go
@@ -51,11 +51,12 @@ type Request struct {
 }
 
 type serializableRequest struct {
-	URL    string
-	Method string
-	Body   []byte
-	ID     uint32
-	Ctx    map[string]interface{}
+	URL     string
+	Method  string
+	Body    []byte
+	ID      uint32
+	Ctx     map[string]interface{}
+	Headers http.Header
 }
 
 // New creates a new request with the context of the original request
@@ -164,10 +165,11 @@ func (r *Request) Marshal() ([]byte, error) {
 		}
 	}
 	return json.Marshal(&serializableRequest{
-		URL:    r.URL.String(),
-		Method: r.Method,
-		Body:   body,
-		ID:     r.ID,
-		Ctx:    ctx,
+		URL:     r.URL.String(),
+		Method:  r.Method,
+		Body:    body,
+		ID:      r.ID,
+		Ctx:     ctx,
+		Headers: *r.Headers,
 	})
 }

--- a/xmlelement.go
+++ b/xmlelement.go
@@ -103,7 +103,6 @@ func (h *XMLElement) ChildText(xpathQuery string) string {
 
 }
 
-
 // ChildAttr returns the stripped text content of the first matching
 // element's attribute.
 func (h *XMLElement) ChildAttr(xpathQuery, attrName string) string {
@@ -154,19 +153,18 @@ func (h *XMLElement) ChildAttrs(xpathQuery, attrName string) []string {
 	return res
 }
 
-// ChildTexts returns an array of strings corresponding to child elements that match the xpath query. 
+// ChildTexts returns an array of strings corresponding to child elements that match the xpath query.
 // Each item in the array is the stripped text content of the corresponding matching child element.
 func (h *XMLElement) ChildTexts(xpathQuery string) []string {
-        texts := make([]string, 0)
-        if h.isHTML {
-                htmlquery.FindEach(h.DOM.(*html.Node), xpathQuery, func(i int, child *html.Node) {
-                        texts = append(texts, strings.TrimSpace(htmlquery.InnerText(child)))
-                                })
-        } else {
-                xmlquery.FindEach(h.DOM.(*xmlquery.Node), xpathQuery, func(i int, child *xmlquery.Node) {
-                        texts = append(texts, strings.TrimSpace(child.InnerText()))
-                })
-        }
-        return texts
+	texts := make([]string, 0)
+	if h.isHTML {
+		htmlquery.FindEach(h.DOM.(*html.Node), xpathQuery, func(i int, child *html.Node) {
+			texts = append(texts, strings.TrimSpace(htmlquery.InnerText(child)))
+		})
+	} else {
+		xmlquery.FindEach(h.DOM.(*xmlquery.Node), xpathQuery, func(i int, child *xmlquery.Node) {
+			texts = append(texts, strings.TrimSpace(child.InnerText()))
+		})
+	}
+	return texts
 }
-

--- a/xmlelement.go
+++ b/xmlelement.go
@@ -89,14 +89,20 @@ func (h *XMLElement) Attr(k string) string {
 // elements.
 func (h *XMLElement) ChildText(xpathQuery string) string {
 	if h.isHTML {
-		return strings.TrimSpace(htmlquery.InnerText(htmlquery.FindOne(h.DOM.(*html.Node), xpathQuery)))
+		child := htmlquery.FindOne(h.DOM.(*html.Node), xpathQuery)
+		if child == nil {
+			return ""
+		}
+		return strings.TrimSpace(htmlquery.InnerText(child))
 	}
-	n := xmlquery.FindOne(h.DOM.(*xmlquery.Node), xpathQuery)
-	if n == nil {
+	child := xmlquery.FindOne(h.DOM.(*xmlquery.Node), xpathQuery)
+	if child == nil {
 		return ""
 	}
-	return strings.TrimSpace(n.InnerText())
+	return strings.TrimSpace(child.InnerText())
+
 }
+
 
 // ChildAttr returns the stripped text content of the first matching
 // element's attribute.
@@ -147,3 +153,20 @@ func (h *XMLElement) ChildAttrs(xpathQuery, attrName string) []string {
 	}
 	return res
 }
+
+// ChildTexts returns an array of strings corresponding to child elements that match the xpath query. 
+// Each item in the array is the stripped text content of the corresponding matching child element.
+func (h *XMLElement) ChildTexts(xpathQuery string) []string {
+        texts := make([]string, 0)
+        if h.isHTML {
+                htmlquery.FindEach(h.DOM.(*html.Node), xpathQuery, func(i int, child *html.Node) {
+                        texts = append(texts, strings.TrimSpace(htmlquery.InnerText(child)))
+                                })
+        } else {
+                xmlquery.FindEach(h.DOM.(*xmlquery.Node), xpathQuery, func(i int, child *xmlquery.Node) {
+                        texts = append(texts, strings.TrimSpace(child.InnerText()))
+                })
+        }
+        return texts
+}
+

--- a/xmlelement_test.go
+++ b/xmlelement_test.go
@@ -14,12 +14,13 @@
 
 package colly_test
 
-import (
-	"strings"
-	"testing"
 
+import (
 	"github.com/antchfx/htmlquery"
 	"github.com/gocolly/colly"
+	"reflect"
+	"strings"
+	"testing"
 )
 
 // Borrowed from http://infohost.nmt.edu/tcc/help/pubs/xhtml/example.html
@@ -72,8 +73,24 @@ func TestChildText(t *testing.T) {
 	if text := xmlElem.ChildText("//p"); text != "This is a regular text paragraph." {
 		t.Fatalf("failed child tag test: %v != This is a regular text paragraph.", text)
 	}
+	if text := xmlElem.ChildText("//dl"); text != "" {
+		t.Fatalf("failed child tag test: %v != \"\"", text)
+	}
 }
 
+func TestChildTexts(t *testing.T) {
+	resp := &colly.Response{StatusCode: 200, Body: []byte(htmlPage)}
+	doc, _ := htmlquery.Parse(strings.NewReader(htmlPage))
+	xmlNode := htmlquery.FindOne(doc, "/html")
+	xmlElem := colly.NewXMLElementFromHTMLNode(resp, xmlNode)
+	expected := []string{"First bullet of a bullet list.", "This is the second bullet."}
+	if texts := xmlElem.ChildTexts("//li"); reflect.DeepEqual(texts, expected) == false {
+		t.Fatalf("failed child tags test: %v != %v", texts, expected)
+	}
+	if texts := xmlElem.ChildTexts("//dl"); reflect.DeepEqual(texts, make([]string, 0)) == false {
+		t.Fatalf("failed child tag test: %v != \"\"", texts)
+	}
+}
 func TestChildAttr(t *testing.T) {
 	resp := &colly.Response{StatusCode: 200, Body: []byte(htmlPage)}
 	doc, _ := htmlquery.Parse(strings.NewReader(htmlPage))

--- a/xmlelement_test.go
+++ b/xmlelement_test.go
@@ -14,7 +14,6 @@
 
 package colly_test
 
-
 import (
 	"github.com/antchfx/htmlquery"
 	"github.com/gocolly/colly"


### PR DESCRIPTION
By converting the http_backend into a implementation of a common
interface, it allows flexibility of using other HTTP clients or
remote browsers to drive HTTP requests. This commit adds the HTTPDriver
interface which provides the same functionality as the http_backend and
updates the Collector to communicate the the http_backend through the
interface methods.

Also attempted to convert the AppEngine call to use the HTTPDriver interface

This is in support of issue #4 