### PR TITLE
Added local files example

### DIFF
--- a/_examples/local_files/html/child_page/one.html
+++ b/_examples/local_files/html/child_page/one.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <h1>Child Page One</h1>
+</body>
+</html>

--- a/_examples/local_files/html/child_page/three.html
+++ b/_examples/local_files/html/child_page/three.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <h1>Child Page Three</h1>
+</body>
+</html>

--- a/_examples/local_files/html/child_page/two.html
+++ b/_examples/local_files/html/child_page/two.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <h1>Child Page Two</h1>
+</body>
+</html>

--- a/_examples/local_files/html/index.html
+++ b/_examples/local_files/html/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <h1>Index.html</h1>
+    <ul>
+        <li><a href="/child_page/one.html"></a></li>
+        <li><a href="/child_page/two.html"></a></li>
+        <li><a href="/child_page/three.html"></a></li>
+    </ul>
+</body>
+</html>

--- a/_examples/local_files/local_files.go
+++ b/_examples/local_files/local_files.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gocolly/colly"
+)
+
+func main() {
+	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		panic(err)
+	}
+
+	t := &http.Transport{}
+	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
+
+	c := colly.NewCollector()
+	c.WithTransport(t)
+
+	pages := []string{}
+
+	c.OnHTML("h1", func(e *colly.HTMLElement) {
+		pages = append(pages, e.Text)
+	})
+
+	c.OnHTML("a", func(e *colly.HTMLElement) {
+		c.Visit("file://" + dir + "/html" + e.Attr("href"))
+	})
+
+	fmt.Println("file://" + dir + "/html/index.html")
+	c.Visit("file://" + dir + "/html/index.html")
+	c.Wait()
+	for i, p := range pages {
+		fmt.Printf("%d : %s\n", i, p)
+	}
+}

--- a/http_backend.go
+++ b/http_backend.go
@@ -179,7 +179,9 @@ func (h *httpBackend) Do(request *http.Request, bodySize int) (*Response, error)
 	if err != nil {
 		return nil, err
 	}
-	*request = *res.Request
+	if res.Request != nil {
+		*request = *res.Request
+	}
 
 	var bodyReader io.Reader = res.Body
 	if bodySize > 0 {


### PR DESCRIPTION
This adds and example for how to use colly to visit local files.
In order for this to work, a slight change was needed to the
`http_backend` to prevent panics when an `http.Response` does not
include the original request, which appears to be the case for the
`FileTransport`.

To run this example, you must run the actual binary and not use
`go run` as the relative paths to the files will be different.