### PR TITLE
Adds Leagify NFL Draft prospect tracker to scraper list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Below is a list of public, open source projects that use Colly:
  * [altsab/gowap](https://github.com/altsab/gowap) Wappalyzer implementation in Go
  * [jesuiscamille/goquotes](https://github.com/jesuiscamille/goquotes) A quotes scrapper, making your day a little better!
  * [jivesearch/jivesearch](https://github.com/jivesearch/jivesearch) A search engine that doesn't track you.
+ * [Leagify/colly-draft-prospects](https://github.com/Leagify/colly-draft-prospects) A scraper for future NFL Draft prospects.
 
 
 If you are using Colly in a project please send a pull request to add it to the list.


### PR DESCRIPTION
Adding link to project as suggested by the README.