### PR TITLE
if the Host header is set, then set the Host field on http.Request

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -515,6 +515,12 @@ func (c *Collector) scrape(u, method string, depth int, requestData io.Reader, c
 	if !ok && requestData != nil {
 		rc = ioutil.NopCloser(requestData)
 	}
+	// The Go HTTP API ignores "Host" in the headers, preferring the client
+	// to use the Host field on Request.
+	host := parsedURL.Host
+	if hostHeader := hdr.Get("Host"); hostHeader != "" {
+		host = hostHeader
+	}
 	req := &http.Request{
 		Method:     method,
 		URL:        parsedURL,
@@ -523,7 +529,7 @@ func (c *Collector) scrape(u, method string, depth int, requestData io.Reader, c
 		ProtoMinor: 1,
 		Header:     hdr,
 		Body:       rc,
-		Host:       parsedURL.Host,
+		Host:       host,
 	}
 	setRequestBody(req, requestData)
 	u = parsedURL.String()


### PR DESCRIPTION
Go handles setting a custom HTTP Host header in kind of a strange way. Instead of adding it to the `Headers` portion of a request, you have to set the `Host` field on the `Request` object itself (https://github.com/golang/go/issues/7682). Instead of trying to duplicate that approach, make it so that `Collector.scrape` will just copy any Host header from the given headers and set the `Host` on req.