### PR TITLE
Fix runtime error when proxy is empty

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -189,6 +189,8 @@ var (
 	ErrNoCookieJar = errors.New("Cookie jar is not available")
 	// ErrNoPattern is the error type for LimitRules without patterns
 	ErrNoPattern = errors.New("No pattern defined in LimitRule")
+	// ErrEmptyProxyURL is the error type for empty Proxy URL list
+	ErrEmptyProxyURL = errors.New("Proxy URL list is empty")
 )
 
 var envMap = map[string]func(*Collector, string){

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -42,6 +42,9 @@ func (r *roundRobinSwitcher) GetProxy(pr *http.Request) (*url.URL, error) {
 // and "socks5" are supported. If the scheme is empty,
 // "http" is assumed.
 func RoundRobinProxySwitcher(ProxyURLs ...string) (colly.ProxyFunc, error) {
+	if len(ProxyURLs) < 1 {
+		return colly.ErrEmptyProxyURL
+	}
 	urls := make([]*url.URL, len(ProxyURLs))
 	for i, u := range ProxyURLs {
 		parsedU, err := url.Parse(u)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -43,7 +43,7 @@ func (r *roundRobinSwitcher) GetProxy(pr *http.Request) (*url.URL, error) {
 // "http" is assumed.
 func RoundRobinProxySwitcher(ProxyURLs ...string) (colly.ProxyFunc, error) {
 	if len(ProxyURLs) < 1 {
-		return colly.ErrEmptyProxyURL
+		return nil,colly.ErrEmptyProxyURL
 	}
 	urls := make([]*url.URL, len(ProxyURLs))
 	for i, u := range ProxyURLs {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -43,7 +43,7 @@ func (r *roundRobinSwitcher) GetProxy(pr *http.Request) (*url.URL, error) {
 // "http" is assumed.
 func RoundRobinProxySwitcher(ProxyURLs ...string) (colly.ProxyFunc, error) {
 	if len(ProxyURLs) < 1 {
-		return nil,colly.ErrEmptyProxyURL
+		return nil, colly.ErrEmptyProxyURL
 	}
 	urls := make([]*url.URL, len(ProxyURLs))
 	for i, u := range ProxyURLs {


### PR DESCRIPTION
```golang
rp, err := proxy.RoundRobinProxySwitcher()
if err != nil {
	log.Fatal(err)
}
```

Code like this will cause a runtime error ,
try to fix this.