### PR TITLE
Tweaks to how xml sitemaps that are decompressed and handled

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -982,7 +982,8 @@ func (c *Collector) handleOnXML(resp *Response) error {
 		return nil
 	}
 	contentType := strings.ToLower(resp.Headers.Get("Content-Type"))
-	if !strings.Contains(contentType, "html") && !strings.Contains(contentType, "xml") {
+	isXMLFile := strings.HasSuffix(strings.ToLower(resp.Request.URL.Path), ".xml") || strings.HasSuffix(strings.ToLower(resp.Request.URL.Path), ".xml.gz")
+	if !strings.Contains(contentType, "html") && (!strings.Contains(contentType, "xml") && !isXMLFile) {
 		return nil
 	}
 
@@ -1012,7 +1013,7 @@ func (c *Collector) handleOnXML(resp *Response) error {
 				cc.Function(e)
 			}
 		}
-	} else if strings.Contains(contentType, "xml") {
+	} else if strings.Contains(contentType, "xml") || isXMLFile {
 		doc, err := xmlquery.Parse(bytes.NewBuffer(resp.Body))
 		if err != nil {
 			return err

--- a/http_backend.go
+++ b/http_backend.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -189,7 +190,8 @@ func (h *httpBackend) Do(request *http.Request, bodySize int) (*Response, error)
 	if bodySize > 0 {
 		bodyReader = io.LimitReader(bodyReader, int64(bodySize))
 	}
-	if !res.Uncompressed && res.Header.Get("Content-Encoding") == "gzip" {
+	contentEncoding := strings.ToLower(res.Header.Get("Content-Encoding"))
+	if !res.Uncompressed && (strings.Contains(contentEncoding, "gzip") || (contentEncoding == "" && strings.Contains(strings.ToLower((res.Header.Get("Content-Type"))), "gzip"))) {
 		bodyReader, err = gzip.NewReader(bodyReader)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This pull request is mostly inspired by past issues I've had with leveraging sitemap files that have odd content encodings when using scrapy: https://github.com/scrapy/scrapy/blob/094dde6fdb1b03351888e437828af5da03f46352/scrapy/spiders/sitemap.py#L67

As per the above linked scrapy handling, some "child" sitemaps are gzipped but the content-encoding is not being set correctly. Instead the `Content-Type` is set to `application/x-gzip`.

Decompress the content as well as handle `.xml` or `.xml.gz` filenames. 

