### PR TITLE
[fix] using URL.Hostname() instead of URL.Host 

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -500,7 +500,7 @@ func (c *Collector) scrape(u, method string, depth int, requestData io.Reader, c
 	if parsedURL.Scheme == "" {
 		parsedURL.Scheme = "http"
 	}
-	if !c.isDomainAllowed(parsedURL.Host) {
+	if !c.isDomainAllowed(parsedURL.Hostname()) {
 		return ErrForbiddenDomain
 	}
 	if method != "HEAD" && !c.IgnoreRobotsTxt {
@@ -1149,7 +1149,7 @@ func (c *Collector) Clone() *Collector {
 
 func (c *Collector) checkRedirectFunc() func(req *http.Request, via []*http.Request) error {
 	return func(req *http.Request, via []*http.Request) error {
-		if !c.isDomainAllowed(req.URL.Host) {
+		if !c.isDomainAllowed(req.URL.Hostname()) {
 			return fmt.Errorf("Not following redirect to %s because its not in AllowedDomains", req.URL.Host)
 		}
 

--- a/colly_test.go
+++ b/colly_test.go
@@ -350,6 +350,43 @@ func TestCollectorVisit(t *testing.T) {
 	}
 }
 
+func TestCollectorVisitWithAllowedDomains(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	c := NewCollector(AllowedDomains("localhost", "127.0.0.1", "::1"))
+	err := c.Visit(ts.URL)
+	if err != nil {
+		t.Errorf("Failed to visit url %s", ts.URL)
+	}
+
+	err = c.Visit("http://example.com")
+	if err != ErrForbiddenDomain {
+		t.Errorf("c.Visit should return ErrForbiddenDomain, but got %v", err)
+	}
+}
+
+func TestCollectorVisitWithDisallowedDomains(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	c := NewCollector(DisallowedDomains("localhost", "127.0.0.1", "::1"))
+	err := c.Visit(ts.URL)
+	if err != ErrForbiddenDomain {
+		t.Errorf("c.Visit should return ErrForbiddenDomain, but got %v", err)
+	}
+
+	c2 := NewCollector(DisallowedDomains("example.com"))
+	err = c2.Visit("http://example.com:8080")
+	if err != ErrForbiddenDomain {
+		t.Errorf("c.Visit should return ErrForbiddenDomain, but got %v", err)
+	}
+	err = c2.Visit(ts.URL)
+	if err != nil {
+		t.Errorf("Failed to visit url %s", ts.URL)
+	}
+}
+
 func TestCollectorOnHTML(t *testing.T) {
 	ts := newTestServer()
 	defer ts.Close()


### PR DESCRIPTION
Using URL.Hostname() instead of URL.Host when calling Collector.isDomainAllowed.
Because the value of URL.Host contains Port number, we should trim it.