### PR TITLE
Remove code that copies headers on redirect

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -1165,13 +1165,6 @@ func (c *Collector) checkRedirectFunc() func(req *http.Request, via []*http.Requ
 
 		lastRequest := via[len(via)-1]
 
-		// Copy the headers from last request
-		for hName, hValues := range lastRequest.Header {
-			for _, hValue := range hValues {
-				req.Header.Set(hName, hValue)
-			}
-		}
-
 		// If domain has changed, remove the Authorization-header if it exists
 		if req.URL.Host != lastRequest.URL.Host {
 			req.Header.Del("Authorization")


### PR DESCRIPTION
The current checkRedirectFunc() copies the headers from the previous locations.  This leads to copying old cookies and possibly other stale information.  The golang default http.Client already copies the necessary headers to build the next request during a redirect before it reaches this code.  Fix for #294 