### PR TITLE
Fix memory leaks via not closing http.Response.Body.

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -702,6 +702,8 @@ func (c *Collector) checkRobots(u *url.URL) error {
 		if err != nil {
 			return err
 		}
+		defer resp.Body.Close()
+
 		robot, err = robotstxt.FromResponse(resp)
 		if err != nil {
 			return err

--- a/http_backend.go
+++ b/http_backend.go
@@ -182,6 +182,7 @@ func (h *httpBackend) Do(request *http.Request, bodySize int) (*Response, error)
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 	if res.Request != nil {
 		*request = *res.Request
 	}
@@ -198,7 +199,6 @@ func (h *httpBackend) Do(request *http.Request, bodySize int) (*Response, error)
 		}
 	}
 	body, err := ioutil.ReadAll(bodyReader)
-	defer res.Body.Close()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When checking robots.txt. The method uses the httpBackend.Client
directly and does not close the response body after usage.

The call to defer res.Body.Close() in httpBackend.Do() was too late to
close the response body after erroring on gzipped compressed bodies.