### PR TITLE
Fix concurrent WebDebugger map read/write

### DIFF
--- a/debug/webdebugger.go
+++ b/debug/webdebugger.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -28,6 +29,7 @@ type WebDebugger struct {
 	initialized     bool
 	CurrentRequests map[uint32]requestInfo
 	RequestLog      []requestInfo
+	sync.Mutex
 }
 
 type requestInfo struct {
@@ -61,6 +63,9 @@ func (w *WebDebugger) Init() error {
 
 // Event updates the debugger's status
 func (w *WebDebugger) Event(e *Event) {
+	w.Lock()
+	defer w.Unlock()
+
 	switch e.Type {
 	case "request":
 		w.CurrentRequests[e.RequestID] = requestInfo{

--- a/debug/webdebugger.go
+++ b/debug/webdebugger.go
@@ -124,11 +124,11 @@ function fetchStatus() {
     $("#request_log_count").text('(' + data.RequestLog.length + ')');
     for(var i in data.CurrentRequests) {
       var r = data.CurrentRequests[i];
-      $("#current_requests").append(curRequestTpl(r.Url, r.Started, r.CollectorId));
+      $("#current_requests").append(curRequestTpl(r.URL, r.Started, r.CollectorID));
     }
     for(var i in data.RequestLog.reverse()) {
       var r = data.RequestLog[i];
-      $("#request_log").append(requestLogTpl(r.Url, r.Duration, r.CollectorId));
+      $("#request_log").append(requestLogTpl(r.URL, r.Duration, r.CollectorID));
     }
     setTimeout(fetchStatus, 1000);
   });
@@ -143,7 +143,9 @@ $(document).ready(function() {
 }
 
 func (w *WebDebugger) statusHandler(wr http.ResponseWriter, r *http.Request) {
+	w.Lock()
 	jsonData, err := json.MarshalIndent(w, "", "  ")
+	w.Unlock()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
When adding a large amount of links it can occur that the ConcurrentRequests map is being written and read at the same time, this fixes it with a Mutex.