### PR TITLE
remove Scheme default for better error message

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -499,9 +499,6 @@ func (c *Collector) scrape(u, method string, depth int, requestData io.Reader, c
 	if err != nil {
 		return err
 	}
-	if parsedURL.Scheme == "" {
-		parsedURL.Scheme = "http"
-	}
 	if !c.isDomainAllowed(parsedURL.Hostname()) {
 		return ErrForbiddenDomain
 	}


### PR DESCRIPTION
Running scrape on a protocol-less url like "go-colly.org" gives a
confusing error message:

```
Error: 0 - Get http://go-colly.org: http: no Host in request URL
```

Here is the code used to create this example:

```golang
package main

import (
	"fmt"

	"github.com/gocolly/colly"
)

func main() {
	c := colly.NewCollector()

	c.OnError(func(r *colly.Response, err error) {
		fmt.Printf("Error: %d - %s \n", r.StatusCode, err)
	})

	c.Visit("go-colly.org")
}
```

The problem is that we added default "http://" Scheme after failing to
parse the "host" out of the URL, but the fact that we don't have a host
means that we won't be able to lookup the url, even after adding the
the "http" to the parsedURL struct.

With this patch, we generate an error that points directly at the issue:

```
Error: 0 - Get go-colly.org: unsupported protocol scheme ""
```