### PR TITLE
Feature/deadline

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -871,6 +871,11 @@ func (c *Collector) SetRequestTimeout(timeout time.Duration) {
 	c.backend.Client.Timeout = timeout
 }
 
+// SetReadDeadline sets the duration of time to allow for reading the response body
+func (c *Collector) SetReadDeadline(deadline time.Duration) {
+	c.backend.ReadDeadline = deadline
+}
+
 // SetStorage overrides the default in-memory storage.
 // Storage stores scraping related data like cookies and visited urls
 func (c *Collector) SetStorage(s storage.Storage) error {

--- a/http_backend.go
+++ b/http_backend.go
@@ -177,7 +177,7 @@ func (h *httpBackend) Do(request *http.Request, bodySize int) (*Response, error)
 			<-r.waitChan
 		}(r)
 	}
-
+	println("DERP")
 	res, err := h.Client.Do(request)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixed a potentially indefinite hang when collecting data from a website that requests an upgrade to websocket.

Accomplished by adding a deadline to the response body read.