### PR TITLE
Fix MAX_DEPTH variable assignment

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -230,7 +230,7 @@ var envMap = map[string]func(*Collector, string){
 	},
 	"MAX_DEPTH": func(c *Collector, val string) {
 		maxDepth, err := strconv.Atoi(val)
-		if err != nil {
+		if err == nil {
 			c.MaxDepth = maxDepth
 		}
 	},


### PR DESCRIPTION
Fix `MAX_DEPTH` variable assignment on the envMap