### PR TITLE
Adds HTTP Tracing to colly requests

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -605,6 +605,9 @@ func (c *Collector) fetch(u, method string, depth int, requestData io.Reader, ct
 		req.Header.Set("Accept", "*/*")
 	}
 
+	hTrace := &HTTPTrace{}
+	req = hTrace.WithTrace(req)
+
 	origURL := req.URL
 	response, err := c.backend.Cache(req, c.MaxBodySize, c.CacheDir)
 	if proxyURL, ok := req.Context().Value(ProxyURLKey).(string); ok {
@@ -620,6 +623,7 @@ func (c *Collector) fetch(u, method string, depth int, requestData io.Reader, ct
 	atomic.AddUint32(&c.responseCount, 1)
 	response.Ctx = ctx
 	response.Request = request
+	response.Trace = hTrace
 
 	err = response.fixCharset(c.DetectCharset, request.ResponseCharacterEncoding)
 	if err != nil {

--- a/colly_test.go
+++ b/colly_test.go
@@ -761,6 +761,23 @@ func TestCollectorOnXML(t *testing.T) {
 	}
 }
 
+func TestCollectorVisitWithTrace(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	c := NewCollector(AllowedDomains("localhost", "127.0.0.1", "::1"))
+	c.OnResponse(func(resp *Response) {
+		if resp.Trace == nil {
+			t.Error("Failed to initialize trace")
+		}
+	})
+
+	err := c.Visit(ts.URL)
+	if err != nil {
+		t.Errorf("Failed to visit url %s", ts.URL)
+	}
+}
+
 func BenchmarkOnHTML(b *testing.B) {
 	ts := newTestServer()
 	defer ts.Close()

--- a/colly_test.go
+++ b/colly_test.go
@@ -765,7 +765,7 @@ func TestCollectorVisitWithTrace(t *testing.T) {
 	ts := newTestServer()
 	defer ts.Close()
 
-	c := NewCollector(AllowedDomains("localhost", "127.0.0.1", "::1"))
+	c := NewCollector(AllowedDomains("localhost", "127.0.0.1", "::1"), TraceHTTP())
 	c.OnResponse(func(resp *Response) {
 		if resp.Trace == nil {
 			t.Error("Failed to initialize trace")

--- a/http_trace.go
+++ b/http_trace.go
@@ -1,0 +1,37 @@
+package colly
+
+import (
+	"net/http"
+	"net/http/httptrace"
+	"time"
+)
+
+// HTTPTrace provides a datastructure for storing an http trace.
+type HTTPTrace struct {
+	start, connect    time.Time
+	ConnectDuration   time.Duration
+	FirstByteDuration time.Duration
+}
+
+// trace returns a httptrace.ClientTrace object to be used with an http
+// request via httptrace.WithClientTrace() that fills in the HttpTrace.
+func (ht *HTTPTrace) trace() *httptrace.ClientTrace {
+	trace := &httptrace.ClientTrace{
+		ConnectStart: func(network, addr string) { ht.connect = time.Now() },
+		ConnectDone: func(network, addr string, err error) {
+			ht.ConnectDuration = time.Since(ht.connect)
+		},
+
+		GetConn: func(hostPort string) { ht.start = time.Now() },
+		GotFirstResponseByte: func() {
+			ht.FirstByteDuration = time.Since(ht.start)
+		},
+	}
+	return trace
+}
+
+// WithTrace returns the given HTTP Request with this HTTPTrace added to its
+// context.
+func (ht *HTTPTrace) WithTrace(req *http.Request) *http.Request {
+	return req.WithContext(httptrace.WithClientTrace(req.Context(), ht.trace()))
+}

--- a/http_trace_test.go
+++ b/http_trace_test.go
@@ -1,0 +1,73 @@
+package colly
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+const testDelay = 200 * time.Millisecond
+
+func newTraceTestServer(delay time.Duration) *httptest.Server {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(delay)
+		w.WriteHeader(200)
+	})
+	mux.HandleFunc("/error", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(delay)
+		w.WriteHeader(500)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestTraceWithNoDelay(t *testing.T) {
+	ts := newTraceTestServer(0)
+	defer ts.Close()
+
+	client := ts.Client()
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	if err != nil {
+		t.Errorf("Failed to construct request %v", err)
+	}
+	trace := &HTTPTrace{}
+	req = trace.WithTrace(req)
+
+	if _, err = client.Do(req); err != nil {
+		t.Errorf("Failed to make request %v", err)
+	}
+
+	if trace.ConnectDuration > testDelay {
+		t.Errorf("trace ConnectDuration should be (almost) 0, got %v", trace.ConnectDuration)
+	}
+	if trace.FirstByteDuration > testDelay {
+		t.Errorf("trace FirstByteDuration should be (almost) 0, got %v", trace.FirstByteDuration)
+	}
+}
+
+func TestTraceWithDelay(t *testing.T) {
+	ts := newTraceTestServer(testDelay)
+	defer ts.Close()
+
+	client := ts.Client()
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	if err != nil {
+		t.Errorf("Failed to construct request %v", err)
+	}
+	trace := &HTTPTrace{}
+	req = trace.WithTrace(req)
+
+	if _, err = client.Do(req); err != nil {
+		t.Errorf("Failed to make request %v", err)
+	}
+
+	if trace.ConnectDuration > testDelay {
+		t.Errorf("trace ConnectDuration should be (almost) 0, got %v", trace.ConnectDuration)
+	}
+	if trace.FirstByteDuration < testDelay {
+		t.Errorf("trace FirstByteDuration should be at least 200ms, got %v", trace.FirstByteDuration)
+	}
+}

--- a/response.go
+++ b/response.go
@@ -38,7 +38,8 @@ type Response struct {
 	Request *Request
 	// Headers contains the Response's HTTP headers
 	Headers *http.Header
-	// Trace contains the HTTPTrace for the request.
+	// Trace contains the HTTPTrace for the request. Will only be set by the
+	// collector if Collector.TraceHTTP is set to true.
 	Trace *HTTPTrace
 }
 

--- a/response.go
+++ b/response.go
@@ -38,6 +38,8 @@ type Response struct {
 	Request *Request
 	// Headers contains the Response's HTTP headers
 	Headers *http.Header
+	// Trace contains the HTTPTrace for the request.
+	Trace *HTTPTrace
 }
 
 // Save writes response body to disk


### PR DESCRIPTION
Go HTTP supports tracing with the "net/http/httptrace" package. This adds a very
basic HTTPTrace object to the HTTP Request that tracks HTTP request timing. **This
is useful for users wanting to tune their crawling based on RTT.**

The resulting trace object is added to the colly Response which is accessible
to a caller via any of the Response callbacks.

Commit includes unit tests for the new HTTPTrace object as well as a new case for colly_test.