### PR TITLE
Cleanup invalid xml characters before unmarshalling

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -37,6 +37,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/antchfx/htmlquery"
@@ -160,6 +161,14 @@ type cookieJarSerializer struct {
 }
 
 var collectorCounter uint32
+
+// used to cleanup xml files before unmarshalling
+var printOnly = func(r rune) rune {
+	if unicode.IsPrint(r) {
+		return r
+	}
+	return -1
+}
 
 // The key type is unexported to prevent collisions with context keys defined in
 // other packages.
@@ -1030,7 +1039,8 @@ func (c *Collector) handleOnXML(resp *Response) error {
 			}
 		}
 	} else if strings.Contains(contentType, "xml") || isXMLFile {
-		doc, err := xmlquery.Parse(bytes.NewBuffer(resp.Body))
+		xmlData := []byte(strings.Map(printOnly, string(resp.Body)))
+		doc, err := xmlquery.Parse(bytes.NewBuffer(xmlData))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
@asciimoo for your consideration here is another PR related to cleanup of xml sitemaps. When unmarshalling xml in go I've run into several sites with bad unicode characters:

```
2019/11/30 18:29:56 Error from https://somesite.com/somethin.xml with status code 200: XML syntax error on line 1: illegal character code U+0003
```

This will cleanup the file before passing onto the xml parser.