### PR TITLE
Update func isDomainAllowed

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -694,6 +694,11 @@ func (c *Collector) isDomainAllowed(domain string) bool {
 		return true
 	}
 	for _, d2 := range c.AllowedDomains {
+		if strings.Contains(domain, d2) {
+			return true
+		}
+	}
+	for _, d2 := range c.AllowedDomains {
 		if d2 == domain {
 			return true
 		}


### PR DESCRIPTION
like scrapy. if c.Visit("http://www.xxxx.com.cn/"), colly.AllowedDomains("xxxx.com.cn") should be work for main domain. so if we request 'www.xxxx.com.cn' and AllowedDomains are 'xxxx.com.cn'. This means that we have access to all subdomains under the top-level domain name