### PR TITLE
Add OnJSON callback function

### DIFF
--- a/jsonstruct.go
+++ b/jsonstruct.go
@@ -1,0 +1,25 @@
+package colly
+
+import "encoding/json"
+
+func ParseJson(resp []byte) ([]map[string]interface{}, error) {
+	var retJsonL []map[string]interface{}
+	if resp[0] == 123 {
+		tmpT := new(map[string]interface{})
+		err := json.Unmarshal(resp, tmpT)
+		if err != nil {
+			return nil, err
+		}
+		retJsonL = append(retJsonL, *tmpT)
+	} else if resp[0] == 91 {
+		tmpT := new([]map[string]interface{})
+		err := json.Unmarshal(resp, tmpT)
+		if err != nil {
+			return nil, err
+		}
+		retJsonL = *tmpT
+	} else {
+		return nil, ErrUnknownJsonStart
+	}
+	return retJsonL, nil
+}


### PR DESCRIPTION
When I was crawling the Github API, I found that I needed to repackage the parsing of dynamic json for OnResponse, so I wanted to submit an OnJSON function

Using Example : 
```golang
c.OnJSON(func(jsonT []map[string]interface{}) {
	for _, row := range jsonT {
		log.Println(row["login"])
	}
})
```

![image](https://user-images.githubusercontent.com/30389809/72503326-66c98280-3876-11ea-9d5f-5b8639c2437f.png)

> I am new to Golang, if the code is not good, please forgive me, tell me, I will modify it