### PR TITLE
Add OnJSON callback function

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -198,7 +198,8 @@ var (
 	// ErrEmptyProxyURL is the error type for empty Proxy URL list
 	ErrEmptyProxyURL = errors.New("Proxy URL list is empty")
 
-	ErrUnknownJsonStart = errors.New("Unknown Json start character")
+	// ErrUnknownJSONStart is the err type for Unknown json character
+	ErrUnknownJSONStart = errors.New("Unknown Json start character")
 )
 
 var envMap = map[string]func(*Collector, string){
@@ -990,20 +991,20 @@ func (c *Collector) handleOnJSON(resp *Response) error {
 	if len(c.jsonCallbacks) == 0 || !strings.Contains(strings.ToLower(resp.Headers.Get("Content-Type")), "application/json") {
 		return nil
 	}
-	JsonT, err := ParseJson(resp.Body)
+	JSONT, err := ParseJSON(resp.Body)
 	if err != nil {
 		return err
 	}
 	if c.debugger != nil {
-		JsonStr, _ := json.Marshal(JsonT)
+		JSONStr, _ := json.Marshal(JSONT)
 		c.debugger.Event(createEvent("json", resp.Request.ID, c.ID, map[string]string{
 			"url":    resp.Request.URL.String(),
-			"json":   string(JsonStr),
+			"json":   string(JSONStr),
 			"status": http.StatusText(resp.StatusCode),
 		}))
 	}
 	for _, ff := range c.jsonCallbacks {
-		ff(JsonT)
+		ff(JSONT)
 	}
 	return nil
 }

--- a/jsonstruct.go
+++ b/jsonstruct.go
@@ -2,24 +2,25 @@ package colly
 
 import "encoding/json"
 
-func ParseJson(resp []byte) ([]map[string]interface{}, error) {
-	var retJsonL []map[string]interface{}
+// AutoCheck and parse Json data
+func ParseJSON(resp []byte) ([]map[string]interface{}, error) {
+	var retJSONL []map[string]interface{}
 	if resp[0] == 123 {
 		tmpT := new(map[string]interface{})
 		err := json.Unmarshal(resp, tmpT)
 		if err != nil {
 			return nil, err
 		}
-		retJsonL = append(retJsonL, *tmpT)
+		retJSONL = append(retJSONL, *tmpT)
 	} else if resp[0] == 91 {
 		tmpT := new([]map[string]interface{})
 		err := json.Unmarshal(resp, tmpT)
 		if err != nil {
 			return nil, err
 		}
-		retJsonL = *tmpT
+		retJSONL = *tmpT
 	} else {
-		return nil, ErrUnknownJsonStart
+		return nil, ErrUnknownJSONStart
 	}
-	return retJsonL, nil
+	return retJSONL, nil
 }

--- a/jsonstruct.go
+++ b/jsonstruct.go
@@ -1,0 +1,25 @@
+package colly
+
+import "encoding/json"
+
+func ParseJson(resp []byte) ([]map[string]interface{}, error) {
+	var retJsonL []map[string]interface{}
+	if resp[0] == 123 {
+		tmpT := new(map[string]interface{})
+		err := json.Unmarshal(resp, tmpT)
+		if err != nil {
+			return nil, err
+		}
+		retJsonL = append(retJsonL, *tmpT)
+	} else if resp[0] == 91 {
+		tmpT := new([]map[string]interface{})
+		err := json.Unmarshal(resp, tmpT)
+		if err != nil {
+			return nil, err
+		}
+		retJsonL = *tmpT
+	} else {
+		return nil, ErrUnknownJsonStart
+	}
+	return retJsonL, nil
+}

--- a/jsonstruct.go
+++ b/jsonstruct.go
@@ -2,7 +2,7 @@ package colly
 
 import "encoding/json"
 
-// AutoCheck and parse Json data
+// ParseJSON is the function to auto check and parse Json data
 func ParseJSON(resp []byte) ([]map[string]interface{}, error) {
 	var retJSONL []map[string]interface{}
 	if resp[0] == 123 {


### PR DESCRIPTION
When I was crawling the Github API, I found that I needed to repackage the parsing of dynamic json for OnResponse, so I wanted to submit an OnJSON function

Using Example :

```golang
c.OnJSON(func(jsonT []map[string]interface{}) {
	for _, row := range jsonT {
		log.Println(row["login"])
	}
})
```

![](https://user-images.githubusercontent.com/30389809/72503326-66c98280-3876-11ea-9d5f-5b8639c2437f.png)

> I am new to Golang, if the code is not good, please forgive me, tell me, I will modify it