### PR TITLE
Fix data race in queue

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -124,7 +124,7 @@ func (q *Queue) Run(c *colly.Collector) error {
 		defer wg.Done()
 		for {
 			if q.IsEmpty() {
-				if q.activeThreadCount == 0 {
+				if atomic.LoadInt32(&q.activeThreadCount) == 0 {
 					q.finish()
 					break
 				}


### PR DESCRIPTION
`Queue.activeThreadCount` is a shared variable. Two goroutines is accessing `Queue.activeThreadCount` without correct synchronization, which can cause data race.
