### PR TITLE
Fix Queue bug

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -10,6 +10,7 @@ import (
 const stop = true
 
 // Storage is the interface of the queue's storage backend
+// Storage must be concurrently safe for multiple goroutines.
 type Storage interface {
 	// Init initializes the storage
 	Init() error

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -158,10 +158,12 @@ func (q *Queue) loop(c *colly.Collector, requestc chan<- *colly.Request, complet
 		var req *colly.Request
 		if size > 0 {
 			req, err = q.loadRequest(c)
-		}
-		if size == 0 || err != nil {
-			// ignore an error returned by GetRequest() or
-			// UnmarshalRequest()
+			if err != nil {
+				// ignore an error returned by GetRequest() or
+				// UnmarshalRequest()
+				continue
+			}
+		} else {
 			sent = nil
 		}
 	Sent:

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -22,7 +22,8 @@ func TestQueue(t *testing.T) {
 		success  uint32
 		failure  uint32
 	)
-	q, err := New(10, nil)
+	storage := &InMemoryQueueStorage{MaxSize: 100000}
+	q, err := New(10, storage)
 	if err != nil {
 		panic(err)
 	}
@@ -34,6 +35,7 @@ func TestQueue(t *testing.T) {
 	}
 	for i := 0; i < 3000; i++ {
 		put()
+		storage.AddRequest([]byte("error request"))
 	}
 	c := colly.NewCollector(
 		colly.AllowURLRevisit(),

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1,0 +1,103 @@
+package queue
+
+import (
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gocolly/colly/v2"
+)
+
+func TestQueue(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(serverHandler))
+	defer server.Close()
+
+	rng := rand.New(rand.NewSource(12387123712321232))
+	var (
+		items    uint32
+		requests uint32
+		success  uint32
+		failure  uint32
+	)
+	q, err := New(10, nil)
+	if err != nil {
+		panic(err)
+	}
+	put := func() {
+		t := time.Duration(rng.Intn(50)) * time.Microsecond
+		url := server.URL + "/delay?t=" + t.String()
+		atomic.AddUint32(&items, 1)
+		q.AddURL(url)
+	}
+	for i := 0; i < 3000; i++ {
+		put()
+	}
+	c := colly.NewCollector(
+		colly.AllowURLRevisit(),
+	)
+	c.OnRequest(func(req *colly.Request) {
+		atomic.AddUint32(&requests, 1)
+	})
+	c.OnResponse(func(resp *colly.Response) {
+		if resp.StatusCode == http.StatusOK {
+			atomic.AddUint32(&success, 1)
+		} else {
+			atomic.AddUint32(&failure, 1)
+		}
+		toss := rng.Intn(2) == 0
+		if toss {
+			put()
+		}
+	})
+	c.OnError(func(resp *colly.Response, err error) {
+		atomic.AddUint32(&failure, 1)
+	})
+	err = q.Run(c)
+	if err != nil {
+		t.Fatalf("Queue.Run() return an error: %v", err)
+	}
+	if items != requests || success+failure != requests || failure > 0 {
+		t.Fatalf("wrong Queue implementation: "+
+			"items = %d, requests = %d, success = %d, failure = %d",
+			items, requests, success, failure)
+	}
+}
+
+func serverHandler(w http.ResponseWriter, req *http.Request) {
+	if !serverRoute(w, req) {
+		shutdown(w)
+	}
+}
+
+func serverRoute(w http.ResponseWriter, req *http.Request) bool {
+	if req.URL.Path == "/delay" {
+		return serveDelay(w, req) == nil
+	}
+	return false
+}
+
+func serveDelay(w http.ResponseWriter, req *http.Request) error {
+	q := req.URL.Query()
+	t, err := time.ParseDuration(q.Get("t"))
+	if err != nil {
+		return err
+	}
+	time.Sleep(t)
+	w.WriteHeader(http.StatusOK)
+	return nil
+}
+
+func shutdown(w http.ResponseWriter) {
+	taker, ok := w.(http.Hijacker)
+	if !ok {
+		return
+	}
+	raw, _, err := taker.Hijack()
+	if err != nil {
+		return
+	}
+	raw.Close()
+}


### PR DESCRIPTION
The existing queue implementation has three drawbacks:
1. Infinite loop (#450)
2. Data race (#449)
3. Last requests may not be executed because of wrong implementation.

The third is a subtle bug. You can see the bug by `go test -v -timeout 10s ./queue` (be sure to checkout master branch and cherry-pick the test commit). The bug might not be shown as the bug is undeterministic.

This pull request addresses the three drawbacks.

I assumes that Storage stored in Queue must not be used by a user while Queue.Run() is running. The assumption can be considered a breaking change to some users. Be careful to merge.
