### PR TITLE
Queue full error

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -202,6 +202,8 @@ var (
 	ErrEmptyProxyURL = errors.New("Proxy URL list is empty")
 	// ErrAbortedAfterHeaders is the error returned when OnResponseHeaders aborts the transfer.
 	ErrAbortedAfterHeaders = errors.New("Aborted after receiving response headers")
+	// ErrQueueFull is the error returned when the queue is full
+	ErrQueueFull = errors.New("Queue MaxSize reached")
 )
 
 var envMap = map[string]func(*Collector, string){

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -165,7 +165,7 @@ func (q *InMemoryQueueStorage) AddRequest(r []byte) error {
 	defer q.lock.Unlock()
 	// Discard URLs if size limit exceeded
 	if q.MaxSize > 0 && q.size >= q.MaxSize {
-		return nil
+		return colly.ErrQueueFull
 	}
 	i := &inMemoryQueueItem{Request: r}
 	if q.first == nil {


### PR DESCRIPTION
Instead of silently failing when adding a request to the queue return an error.