### PR TITLE
Add methods to InMemoryQueueStorage to allow requests without serialization

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -504,7 +504,7 @@ func (c *Collector) SetDebugger(d debug.Debugger) {
 
 // UnmarshalRequest creates a Request from serialized data
 func (c *Collector) UnmarshalRequest(r []byte) (*Request, error) {
-	req := &serializableRequest{}
+	req := &SerializableRequest{}
 	err := json.Unmarshal(r, req)
 	if err != nil {
 		return nil, err

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -28,14 +28,20 @@ func TestQueue(t *testing.T) {
 		panic(err)
 	}
 	put := func() {
-		t := time.Duration(rng.Intn(50)) * time.Microsecond
-		url := server.URL + "/delay?t=" + t.String()
+		d := time.Duration(rng.Intn(50)) * time.Microsecond
+		url := server.URL + "/delay?t=" + d.String()
 		atomic.AddUint32(&items, 1)
-		q.AddURL(url)
+		err := q.AddURL(url)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 	for i := 0; i < 3000; i++ {
 		put()
-		storage.AddRequest([]byte("error request"))
+		err := storage.AddRequest([]byte("error request"))
+		if err == nil {
+			t.Errorf("Adding an error request shoud result in an error")
+		}
 	}
 	c := colly.NewCollector(
 		colly.AllowURLRevisit(),

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -40,7 +40,7 @@ func TestQueue(t *testing.T) {
 		put()
 		err := storage.AddRequest([]byte("error request"))
 		if err == nil {
-			t.Errorf("Adding an error request shoud result in an error")
+			t.Errorf("Adding an error request should result in an error")
 		}
 	}
 	c := colly.NewCollector(

--- a/request.go
+++ b/request.go
@@ -52,7 +52,8 @@ type Request struct {
 	ProxyURL string
 }
 
-type serializableRequest struct {
+// Serializable representation of Request
+type SerializableRequest struct {
 	URL     string
 	Method  string
 	Depth   int
@@ -173,7 +174,7 @@ func (r *Request) Marshal() ([]byte, error) {
 			return nil, err
 		}
 	}
-	sr := &serializableRequest{
+	sr := &SerializableRequest{
 		URL:    r.URL.String(),
 		Method: r.Method,
 		Depth:  r.Depth,


### PR DESCRIPTION
Added the methods AddRequestPointer and GetRequestPointer to allow for working with InMemoryQueStorage without having to use Serialization.

I had to make SerializableRequest public to allow it to be used from the Queue package 