### PR TITLE
Fix relative <base> URL

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -1057,7 +1057,7 @@ func (c *Collector) handleOnHTML(resp *Response) error {
 		return err
 	}
 	if href, found := doc.Find("base[href]").Attr("href"); found {
-		resp.Request.baseURL, _ = url.Parse(href)
+		resp.Request.baseURL, _ = resp.Request.URL.Parse(href)
 	}
 	for _, cc := range c.htmlCallbacks {
 		i := 0
@@ -1096,7 +1096,7 @@ func (c *Collector) handleOnXML(resp *Response) error {
 		if e := htmlquery.FindOne(doc, "//base"); e != nil {
 			for _, a := range e.Attr {
 				if a.Key == "href" {
-					resp.Request.baseURL, _ = url.Parse(a.Val)
+					resp.Request.baseURL, _ = resp.Request.URL.Parse(a.Val)
 					break
 				}
 			}


### PR DESCRIPTION
The base itself can be relative, this is documented[1], and rarely
happens on the websites in the wild.

[1] https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base