### PR TITLE
Fixed binary files (images, videos and etc.) encoding as a text/plain

### DIFF
--- a/response.go
+++ b/response.go
@@ -76,7 +76,7 @@ func (r *Response) fixCharset(detectCharset bool, defaultEncoding string) error 
 
 		return nil
 	}
-	
+
 	if defaultEncoding != "" {
 		tmpBody, err := encodeBytes(r.Body, "text/plain; charset="+defaultEncoding)
 		if err != nil {

--- a/response.go
+++ b/response.go
@@ -65,14 +65,7 @@ func (r *Response) fixCharset(detectCharset bool, defaultEncoding string) error 
 	if len(r.Body) == 0 {
 		return nil
 	}
-	if defaultEncoding != "" {
-		tmpBody, err := encodeBytes(r.Body, "text/plain; charset="+defaultEncoding)
-		if err != nil {
-			return err
-		}
-		r.Body = tmpBody
-		return nil
-	}
+
 	contentType := strings.ToLower(r.Headers.Get("Content-Type"))
 
 	if strings.Contains(contentType, "image/") ||
@@ -81,6 +74,15 @@ func (r *Response) fixCharset(detectCharset bool, defaultEncoding string) error 
 		strings.Contains(contentType, "font/") {
 		// These MIME types should not have textual data.
 
+		return nil
+	}
+	
+	if defaultEncoding != "" {
+		tmpBody, err := encodeBytes(r.Body, "text/plain; charset="+defaultEncoding)
+		if err != nil {
+			return err
+		}
+		r.Body = tmpBody
 		return nil
 	}
 


### PR DESCRIPTION
Bug: encoding a binary file data as a text/plain if a Content-Type charset not empty and equals binary or other

Two different files (curl'ed for debug):
![image](https://user-images.githubusercontent.com/3829167/82043806-a50c6c80-96c5-11ea-998f-ef3fe0ad4590.png)
![image](https://user-images.githubusercontent.com/3829167/82043872-bfdee100-96c5-11ea-9efc-548e51b050ab.png)

Two files downloaded by the gocolly.
First red rectangle is a good file, second is a bad file. 
**Look around a "JFIFHH" magic symbol!**
![image](https://user-images.githubusercontent.com/3829167/82043936-e0a73680-96c5-11ea-8def-7452d5176738.png)

