### PR TITLE
Make allowances for responses with missing ContentLength

### DIFF
--- a/http_backend.go
+++ b/http_backend.go
@@ -208,7 +208,10 @@ func (h *httpBackend) Do(request *http.Request, bodySize int, checkHeadersFunc c
 	}
 	body, err := ioutil.ReadAll(bodyReader)
 	if err != nil {
-		return nil, err
+		// Make allowances for broken servers that don't sent a content length.
+		if err != io.ErrUnexpectedEOF || res.ContentLength != -1 {
+			return nil, err
+		}
 	}
 	return &Response{
 		StatusCode: res.StatusCode,


### PR DESCRIPTION
This makes colly more permissive to servers that don't send a ContentLength header.

Fixes https://github.com/gocolly/colly/issues/511