### PR TITLE
Defines an HTTPBackend interface to use with Colly.

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -122,7 +122,7 @@ type Collector struct {
 	scrapedCallbacks         []ScrapedCallback
 	requestCount             uint32
 	responseCount            uint32
-	backend                  *httpBackend
+	backend                  HTTPBackend
 	wg                       *sync.WaitGroup
 	lock                     *sync.RWMutex
 }
@@ -217,7 +217,7 @@ var envMap = map[string]func(*Collector, string){
 		c.DetectCharset = isYesString(val)
 	},
 	"DISABLE_COOKIES": func(c *Collector, _ string) {
-		c.backend.Client.Jar = nil
+		c.backend.SetJar(nil)
 	},
 	"DISALLOWED_DOMAINS": func(c *Collector, val string) {
 		c.DisallowedDomains = strings.Split(val, ",")
@@ -402,10 +402,10 @@ func (c *Collector) Init() {
 	c.store = &storage.InMemoryStorage{}
 	c.store.Init()
 	c.MaxBodySize = 10 * 1024 * 1024
-	c.backend = &httpBackend{}
+	c.backend = &httpClientBackend{}
 	jar, _ := cookiejar.New(nil)
 	c.backend.Init(jar)
-	c.backend.Client.CheckRedirect = c.checkRedirectFunc()
+	c.backend.SetCheckRedirect(c.checkRedirectFunc())
 	c.wg = &sync.WaitGroup{}
 	c.lock = &sync.RWMutex{}
 	c.robotsMap = make(map[string]*robotstxt.RobotsData)
@@ -426,12 +426,13 @@ func (c *Collector) Init() {
 //     c.Visit("https://google.ca")
 //   }
 func (c *Collector) Appengine(ctx context.Context) {
-	client := urlfetch.Client(ctx)
-	client.Jar = c.backend.Client.Jar
-	client.CheckRedirect = c.backend.Client.CheckRedirect
-	client.Timeout = c.backend.Client.Timeout
 
-	c.backend.Client = client
+	client := urlfetch.Client(ctx)
+	client.Jar = c.backend.GetJar()
+	client.CheckRedirect = c.backend.GetCheckRedirect()
+	client.Timeout = c.backend.GetTimeout()
+
+	c.backend.SetClient(client)
 }
 
 // Visit starts Collector's collecting job by creating a
@@ -763,7 +764,8 @@ func (c *Collector) checkRobots(u *url.URL) error {
 
 	if !ok {
 		// no robots file cached
-		resp, err := c.backend.Client.Get(u.Scheme + "://" + u.Host + "/robots.txt")
+		resp, err := c.backend.Get(u.Scheme + "://" + u.Host + "/robots.txt")
+
 		if err != nil {
 			return err
 		}
@@ -935,28 +937,28 @@ func (c *Collector) OnScraped(f ScrapedCallback) {
 }
 
 // SetClient will override the previously set http.Client
-func (c *Collector) SetClient(client *http.Client) {
-	c.backend.Client = client
+func (c *Collector) SetClient(client *http.Client) error {
+	return c.backend.SetClient(client)
 }
 
 // WithTransport allows you to set a custom http.RoundTripper (transport)
 func (c *Collector) WithTransport(transport http.RoundTripper) {
-	c.backend.Client.Transport = transport
+	c.backend.SetTransport(transport)
 }
 
 // DisableCookies turns off cookie handling
 func (c *Collector) DisableCookies() {
-	c.backend.Client.Jar = nil
+	c.backend.SetJar(nil)
 }
 
 // SetCookieJar overrides the previously set cookie jar
 func (c *Collector) SetCookieJar(j http.CookieJar) {
-	c.backend.Client.Jar = j
+	c.backend.SetJar(j)
 }
 
 // SetRequestTimeout overrides the default timeout (10 seconds) for this collector
 func (c *Collector) SetRequestTimeout(timeout time.Duration) {
-	c.backend.Client.Timeout = timeout
+	c.backend.SetTimeout(timeout)
 }
 
 // SetStorage overrides the default in-memory storage.
@@ -966,7 +968,7 @@ func (c *Collector) SetStorage(s storage.Storage) error {
 		return err
 	}
 	c.store = s
-	c.backend.Client.Jar = createJar(s)
+	c.backend.SetJar(createJar(s))
 	return nil
 }
 
@@ -994,14 +996,7 @@ func (c *Collector) SetProxy(proxyURL string) error {
 // and "socks5" are supported. If the scheme is empty,
 // "http" is assumed.
 func (c *Collector) SetProxyFunc(p ProxyFunc) {
-	t, ok := c.backend.Client.Transport.(*http.Transport)
-	if c.backend.Client.Transport != nil && ok {
-		t.Proxy = p
-	} else {
-		c.backend.Client.Transport = &http.Transport{
-			Proxy: p,
-		}
-	}
+	c.backend.SetProxy(p)
 }
 
 func createEvent(eventType string, requestID, collectorID uint32, kvargs map[string]string) *debug.Event {
@@ -1191,32 +1186,32 @@ func (c *Collector) Limits(rules []*LimitRule) error {
 // SetRedirectHandler instructs the Collector to allow multiple downloads of the same URL
 func (c *Collector) SetRedirectHandler(f func(req *http.Request, via []*http.Request) error) {
 	c.redirectHandler = f
-	c.backend.Client.CheckRedirect = c.checkRedirectFunc()
+	c.backend.SetCheckRedirect(c.checkRedirectFunc())
 }
 
 // SetCookies handles the receipt of the cookies in a reply for the given URL
 func (c *Collector) SetCookies(URL string, cookies []*http.Cookie) error {
-	if c.backend.Client.Jar == nil {
+	if c.backend.GetJar() == nil {
 		return ErrNoCookieJar
 	}
 	u, err := url.Parse(URL)
 	if err != nil {
 		return err
 	}
-	c.backend.Client.Jar.SetCookies(u, cookies)
+	c.backend.SetCookies(u, cookies)
 	return nil
 }
 
 // Cookies returns the cookies to send in a request for the given URL.
 func (c *Collector) Cookies(URL string) []*http.Cookie {
-	if c.backend.Client.Jar == nil {
+	if c.backend.GetJar() == nil {
 		return nil
 	}
 	u, err := url.Parse(URL)
 	if err != nil {
 		return nil
 	}
-	return c.backend.Client.Jar.Cookies(u)
+	return c.backend.GetCookies(u)
 }
 
 // Clone creates an exact copy of a Collector without callbacks.


### PR DESCRIPTION
This interface is designed to support using different backends for fetching data, specifically to support a future PR using chromedp as a backend to support parsing sites that rely on .js to populate data.

It's based off of work by @mazhigali in https://github.com/gocolly/colly/pull/503/files, with some simplifications and tweaks to naming conventions. I'm looking to use a chromedp based scraper in a project I'm doing, so wanted to progress that PR given it's gone a little quiet, but happy to work back on it in a different way if you or @mazhigali would prefer.

The intent is to provide a fast follow with an implementation of a chromedp based backend as well as modifications to colly.go to support setting up with different backends, with this first PR setting up for that with a smaller changeset that's hopefully easier to review.

I haven't added tests for this as it's largely just getters/setters rather than substantive code, but I can work back on that as preferred.

Testing was done by running some of the colly examples as well as using the pre-written tests.

Thanks!