### PR TITLE
Fix handling of redirected URLs in OnResponseHeaders

### DIFF
--- a/colly_test.go
+++ b/colly_test.go
@@ -778,9 +778,16 @@ func TestRedirect(t *testing.T) {
 			t.Error("Invalid URL after redirect: " + u)
 		}
 	})
+
+	c.OnResponseHeaders(func(r *Response) {
+		if !strings.HasSuffix(r.Request.URL.String(), "/redirected/") {
+			t.Error("Invalid URL in Request after redirect (OnResponseHeaders): " + r.Request.URL.String())
+		}
+	})
+
 	c.OnResponse(func(r *Response) {
 		if !strings.HasSuffix(r.Request.URL.String(), "/redirected/") {
-			t.Error("Invalid URL in Request after redirect: " + r.Request.URL.String())
+			t.Error("Invalid URL in Request after redirect (OnResponse): " + r.Request.URL.String())
 		}
 	})
 	c.Visit(ts.URL + "/redirect")

--- a/http_backend.go
+++ b/http_backend.go
@@ -40,7 +40,7 @@ type httpBackend struct {
 	lock       *sync.RWMutex
 }
 
-type checkHeadersFunc func(statusCode int, header http.Header) bool
+type checkHeadersFunc func(req *http.Request, statusCode int, header http.Header) bool
 
 // LimitRule provides connection restrictions for domains.
 // Both DomainRegexp and DomainGlob can be used to specify
@@ -188,7 +188,7 @@ func (h *httpBackend) Do(request *http.Request, bodySize int, checkHeadersFunc c
 	if res.Request != nil {
 		*request = *res.Request
 	}
-	if !checkHeadersFunc(res.StatusCode, res.Header) {
+	if !checkHeadersFunc(request, res.StatusCode, res.Header) {
 		// closing res.Body (see defer above) without reading it aborts
 		// the download
 		return nil, ErrAbortedAfterHeaders


### PR DESCRIPTION
When `OnResponse` callback is called, the request URL is updated to reflect the redirect that has been followed (if any).

Do the same for `OnResponseHeaders`, for consistency.