### PR TITLE
SetProxyFunc: fix proxies rotation

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -1012,9 +1012,11 @@ func (c *Collector) SetProxyFunc(p ProxyFunc) {
 	t, ok := c.backend.Client.Transport.(*http.Transport)
 	if c.backend.Client.Transport != nil && ok {
 		t.Proxy = p
+		t.DisableKeepAlives = true
 	} else {
 		c.backend.Client.Transport = &http.Transport{
-			Proxy: p,
+			Proxy:             p,
+			DisableKeepAlives: true,
 		}
 	}
 }


### PR DESCRIPTION
Hey!
I think `SetProxyFunc()` could simply override `DisableKeepAlives` and set it `true` as the default value. Otherwise, it will rotate proxies only on failed requests.

Also, you can reproduce this issue exactly with the example http://go-colly.org/docs/examples/proxy_switcher/

This PR addresses the issue #339 