### PR TITLE
Fix require github.com/gocolly/colly/v2: version "latest" invalid: must be of the form v1.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ module github.com/x/y
 go 1.14
 
 require (
-        github.com/gocolly/colly/v2 latest
+        github.com/gocolly/colly/v2 v2.1.0
 )
 ```
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13204332/107331419-d3e92f00-6aed-11eb-8649-1bb2b37a91f7.png)
