### PR TITLE
Remove tabs and newlines from URLs

### DIFF
--- a/colly_test.go
+++ b/colly_test.go
@@ -156,6 +156,36 @@ func newTestServer() *httptest.Server {
 		`))
 	})
 
+	mux.HandleFunc("/tabs_and_newlines", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<!DOCTYPE html>
+<html>
+<head>
+<title>Test Page</title>
+<base href="/foo	bar/" />
+</head>
+<body>
+<a href="x
+y">link</a>
+</body>
+</html>
+		`))
+	})
+
+	mux.HandleFunc("/foobar/xy", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<!DOCTYPE html>
+<html>
+<head>
+<title>Test Page</title>
+</head>
+<body>
+<p>hello</p>
+</body>
+</html>
+		`))
+	})
+
 	mux.HandleFunc("/large_binary", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/octet-stream")
 		ww := bufio.NewWriter(w)
@@ -839,6 +869,34 @@ func TestBaseTagRelative(t *testing.T) {
 		}
 	})
 	c2.Visit(ts.URL + "/base_relative")
+}
+
+func TestTabsAndNewlines(t *testing.T) {
+	// this test might look odd, but see step 3 of
+	// https://url.spec.whatwg.org/#concept-basic-url-parser
+
+	ts := newTestServer()
+	defer ts.Close()
+
+	visited := map[string]struct{}{}
+	expected := map[string]struct{}{
+		"/tabs_and_newlines": {},
+		"/foobar/xy":         {},
+	}
+
+	c := NewCollector()
+	c.OnResponse(func(res *Response) {
+		visited[res.Request.URL.EscapedPath()] = struct{}{}
+	})
+	c.OnHTML("a[href]", func(e *HTMLElement) {
+		e.Request.Visit(e.Attr("href"))
+	})
+
+	c.Visit(ts.URL + "/tabs_and_newlines")
+
+	if !reflect.DeepEqual(visited, expected) {
+		t.Errorf("visited=%v expected=%v", visited, expected)
+	}
 }
 
 func TestCollectorCookies(t *testing.T) {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -75,7 +75,7 @@ func (q *Queue) IsEmpty() bool {
 
 // AddURL adds a new URL to the queue
 func (q *Queue) AddURL(URL string) error {
-	u, err := url.Parse(URL)
+	u, err := url.Parse(colly.RemoveAsciiTabAndNewlines(URL))
 	if err != nil {
 		return err
 	}

--- a/request.go
+++ b/request.go
@@ -64,7 +64,7 @@ type serializableRequest struct {
 
 // New creates a new request with the context of the original request
 func (r *Request) New(method, URL string, body io.Reader) (*Request, error) {
-	u, err := url.Parse(URL)
+	u, err := url.Parse(RemoveAsciiTabAndNewlines(URL))
 	if err != nil {
 		return nil, err
 	}
@@ -88,6 +88,7 @@ func (r *Request) Abort() {
 // AbsoluteURL returns empty string if the URL chunk is a fragment or
 // could not be parsed
 func (r *Request) AbsoluteURL(u string) string {
+	u = RemoveAsciiTabAndNewlines(u)
 	if strings.HasPrefix(u, "#") {
 		return ""
 	}


### PR DESCRIPTION
This might sound weird, but both URL standard[1] specifies it,
and browsers do that as well.

Although the standard specifies it as a "validation error",
this is not a hard error.

This actually happens in the wild: as of now, this Google's page[2]
has the following fragment:

    <a class="glue-header__link"
                                  href="/intl/ru_ALL
    /drive/download/"
    >

Yes, the newline here is in the middle of the link, and browsers
do ignore it.

[1] https://url.spec.whatwg.org/#concept-basic-url-parser
[2] https://www.google.com/intl/ru/drive/download/