### PR TITLE
Bypass request delay when request is cancelled

### DIFF
--- a/extensions/random_user_agent.go
+++ b/extensions/random_user_agent.go
@@ -264,10 +264,10 @@ func genChromeUA() string {
 //	-> "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.72 Safari/537.36 Edg/90.0.818.39"
 func genEdgeUA() string {
 	version := edgeVersions[rand.Intn(len(edgeVersions))]
-	chrome_version := strings.Split(version, ",")[0]
-	edge_version := strings.Split(version, ",")[1]
+	chromeVersion := strings.Split(version, ",")[0]
+	edgeVersion := strings.Split(version, ",")[1]
 	os := osStrings[rand.Intn(len(osStrings))]
-	return fmt.Sprintf("Mozilla/5.0 (%s) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Safari/537.36 Edg/%s", os, chrome_version, edge_version)
+	return fmt.Sprintf("Mozilla/5.0 (%s) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Safari/537.36 Edg/%s", os, chromeVersion, edgeVersion)
 }
 
 // Generates Opera Browser User-Agent (Desktop)

--- a/http_backend.go
+++ b/http_backend.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha1"
 	"encoding/gob"
 	"encoding/hex"
+	"errors"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -173,7 +174,7 @@ func (h *httpBackend) Do(request *http.Request, bodySize int, checkHeadersFunc c
 		select {
 		case r.waitChan <- true:
 		case <-request.Context().Done():
-			return nil, request.Context().Err()
+			return nil, errors.New("context canceled; early return")
 		}
 
 		defer func(r *LimitRule) {

--- a/http_backend_test.go
+++ b/http_backend_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 func TestHTTPBackendDoCancelation(t *testing.T) {
-	rand.Seed(time.Now().Unix())
+	// hardcoded fixed to ensure that p, n, c are the same making the test more reliable
+	rand.Seed(2927496558871806)
 
 	// rand up to 10 to not extend the test duration too much
 	p := 1 + rand.Intn(5)        // p: parallel requests

--- a/http_backend_test.go
+++ b/http_backend_test.go
@@ -51,7 +51,8 @@ func TestHTTPBackendDoCancelation(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 
-			req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/"+strconv.Itoa(i), nil)
+			req, _ := http.NewRequest("GET", ts.URL+"/"+strconv.Itoa(i), nil)
+			req = req.WithContext(ctx)
 			_, err := backend.Do(req, 0, checkHeadersFunc)
 			errs <- err
 		}(i)

--- a/http_backend_test.go
+++ b/http_backend_test.go
@@ -77,7 +77,7 @@ func TestHTTPBackendDoCancelation(t *testing.T) {
 				t.Errorf("no error was expected for the first %d responses; error: %q", n, err)
 			}
 		} else {
-			if !strings.Contains(err.Error(), "context canceled") {
+			if err == nil || !strings.Contains(err.Error(), "context canceled") {
 				t.Error("call to Do should return with error from terminated context")
 			}
 		}

--- a/http_backend_test.go
+++ b/http_backend_test.go
@@ -1,0 +1,97 @@
+package colly
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestHTTPBackendDoCancelation(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(rw, "OK")
+	}))
+	defer ts.Close()
+
+	checkHeadersFunc := func(req *http.Request, statusCode int, header http.Header) bool { return true }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	backend := &httpBackend{}
+	jar, _ := cookiejar.New(nil)
+	backend.Init(jar)
+	limit := &LimitRule{
+		DomainRegexp: ".*",
+		Parallelism:  1,
+		Delay:        5 * time.Millisecond,
+	}
+	backend.Limit(limit)
+
+	rand.Seed(time.Now().Unix())
+
+	// rand up to 10 to not extend the test duration too much
+	n := rand.Intn(10)
+	c := n + rand.Intn(10)
+
+	var wg sync.WaitGroup
+	wg.Add(c)
+
+	errs := make(chan error)
+
+	begin := time.Now()
+	for i := 0; i < c; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/"+strconv.Itoa(i), nil)
+			_, err := backend.Do(req, 0, checkHeadersFunc)
+			errs <- err
+		}(i)
+	}
+
+	var d time.Duration
+	go func() {
+		wg.Wait()
+		d = time.Since(begin) // captures the duration of all calls
+		close(errs)
+	}()
+
+	i := 0
+	for err := range errs {
+		i++
+		if i == n {
+			cancel()
+		}
+
+		if i <= n {
+			if err != nil {
+				t.Errorf("no error was expected for the first %d responses; error: %q", n, err)
+			}
+		} else {
+			if !strings.Contains(err.Error(), "context canceled") {
+				t.Error("call to Do should return with error from terminated context")
+			}
+		}
+	}
+
+	// the expectation is n+1 because:
+	//     n: that time should have already passed, cancel is done after the second response
+	//     1: the third request is cancelled just after starting forces delay
+	if d < time.Duration(n+1)*limit.Delay {
+		t.Error("duration is bellow the expected")
+	}
+
+	// n+1+1 is the max limit because after the minimum delay the other calls should finish
+	// immediately since the function return before defer was set
+	if d > time.Duration(n+1+1)*limit.Delay {
+		t.Error("duration is above the expected")
+	}
+}


### PR DESCRIPTION
Before this PR: after cancelling a context for a collector all requests failed with "context canceled" but the delay set by the limit rules still applies.
The intention here is to terminate the collector as soon as possible after its context finishes.