### PR TITLE
Work around invalid URL encoding in path

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -260,6 +260,8 @@ var envMap = map[string]func(*Collector, string){
 	},
 }
 
+var urlParser = whatwgUrl.NewParser(whatwgUrl.WithPercentEncodeSinglePercentSign())
+
 // NewCollector creates a new Collector instance with default configuration
 func NewCollector(options ...CollectorOption) *Collector {
 	c := &Collector{}
@@ -550,7 +552,7 @@ func (c *Collector) UnmarshalRequest(r []byte) (*Request, error) {
 }
 
 func (c *Collector) scrape(u, method string, depth int, requestData io.Reader, ctx *Context, hdr http.Header, checkRevisit bool) error {
-	parsedWhatwgURL, err := whatwgUrl.Parse(u)
+	parsedWhatwgURL, err := urlParser.Parse(u)
 	if err != nil {
 		return err
 	}
@@ -1082,7 +1084,7 @@ func (c *Collector) handleOnHTML(resp *Response) error {
 		return err
 	}
 	if href, found := doc.Find("base[href]").Attr("href"); found {
-		u, err := whatwgUrl.ParseRef(resp.Request.URL.String(), href)
+		u, err := urlParser.ParseRef(resp.Request.URL.String(), href)
 		if err == nil {
 			baseURL, err := url.Parse(u.Href(false))
 			if err == nil {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -11,6 +11,8 @@ import (
 
 const stop = true
 
+var urlParser = whatwgUrl.NewParser(whatwgUrl.WithPercentEncodeSinglePercentSign())
+
 // Storage is the interface of the queue's storage backend
 // Storage must be concurrently safe for multiple goroutines.
 type Storage interface {
@@ -77,7 +79,7 @@ func (q *Queue) IsEmpty() bool {
 
 // AddURL adds a new URL to the queue
 func (q *Queue) AddURL(URL string) error {
-	u, err := whatwgUrl.Parse(URL)
+	u, err := urlParser.Parse(URL)
 	if err != nil {
 		return err
 	}

--- a/request.go
+++ b/request.go
@@ -23,8 +23,6 @@ import (
 	"net/url"
 	"strings"
 	"sync/atomic"
-
-	whatwgUrl "github.com/nlnwa/whatwg-url/url"
 )
 
 // Request is the representation of a HTTP request made by a Collector
@@ -66,7 +64,7 @@ type serializableRequest struct {
 
 // New creates a new request with the context of the original request
 func (r *Request) New(method, URL string, body io.Reader) (*Request, error) {
-	u, err := whatwgUrl.Parse(URL)
+	u, err := urlParser.Parse(URL)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +102,7 @@ func (r *Request) AbsoluteURL(u string) string {
 		base = r.URL
 	}
 
-	absURL, err := whatwgUrl.ParseRef(base.String(), u)
+	absURL, err := urlParser.ParseRef(base.String(), u)
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
Go `net/http` cannot send HTTP requests containing invalid URL encoding in path (e.g. bare percent)
at all[1]. Browsers send a bare percent in such scenario, and do not implicitly autoencode it.

Until the upstream issue is resolved somehow, we have only two alternatives: either fail to fetch such URLs, or at least attempt the autoencoded variant. Lots of webservers handle them the same way, so it's worth trying.

There aren't too many websites with invalid URL encoding in path component, though.

[1] https://github.com/golang/go/issues/29808