### PR TITLE
Host & Custom Header Support

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -56,6 +56,8 @@ type CollectorOption func(*Collector)
 type Collector struct {
 	// UserAgent is the User-Agent string used by HTTP requests
 	UserAgent string
+	// Custom headers for the request
+	Headers *http.Header
 	// MaxDepth limits the recursion depth of visited URLs.
 	// Set it to 0 for infinite recursion (default).
 	MaxDepth int
@@ -281,6 +283,17 @@ func UserAgent(ua string) CollectorOption {
 	}
 }
 
+// Header sets the custom headers used by the Collector.
+func Headers(headers map[string]string) CollectorOption {
+	return func(c *Collector) {
+		custom_headers := make(http.Header)
+		for header, value := range headers {
+			custom_headers.Add(header, value)
+		}
+		c.Headers = &custom_headers
+	}
+}
+
 // MaxDepth limits the recursion depth of visited URLs.
 func MaxDepth(depth int) CollectorOption {
 	return func(c *Collector) {
@@ -415,6 +428,7 @@ func CheckHead() CollectorOption {
 // configuration for the Collector
 func (c *Collector) Init() {
 	c.UserAgent = "colly - https://github.com/gocolly/colly/v2"
+	c.Headers = nil
 	c.MaxDepth = 0
 	c.store = &storage.InMemoryStorage{}
 	c.store.Init()
@@ -568,6 +582,13 @@ func (c *Collector) scrape(u, method string, depth int, requestData io.Reader, c
 
 	if hdr == nil {
 		hdr = http.Header{}
+		if c.Headers != nil {
+			for k, v := range *c.Headers {
+				for _, value := range v {
+					hdr.Add(k, value)
+				}
+			}
+		}
 	}
 	if _, ok := hdr["User-Agent"]; !ok {
 		hdr.Set("User-Agent", c.UserAgent)
@@ -645,6 +666,7 @@ func (c *Collector) fetch(u, method string, depth int, requestData io.Reader, ct
 	request := &Request{
 		URL:       req.URL,
 		Headers:   &req.Header,
+		Host:      req.Host,
 		Ctx:       ctx,
 		Depth:     depth,
 		Method:    method,
@@ -1284,6 +1306,7 @@ func (c *Collector) Clone() *Collector {
 		CheckHead:              c.CheckHead,
 		ParseHTTPErrorResponse: c.ParseHTTPErrorResponse,
 		UserAgent:              c.UserAgent,
+		Headers:                c.Headers,
 		TraceHTTP:              c.TraceHTTP,
 		Context:                c.Context,
 		store:                  c.store,

--- a/request.go
+++ b/request.go
@@ -33,6 +33,8 @@ type Request struct {
 	URL *url.URL
 	// Headers contains the Request's HTTP headers
 	Headers *http.Header
+	// the Host header
+	Host string
 	// Ctx is a context between a Request and a Response
 	Ctx *Context
 	// Depth is the number of the parents of the request
@@ -62,6 +64,7 @@ type serializableRequest struct {
 	ID      uint32
 	Ctx     map[string]interface{}
 	Headers http.Header
+	Host    string
 }
 
 // New creates a new request with the context of the original request
@@ -80,6 +83,7 @@ func (r *Request) New(method, URL string, body io.Reader) (*Request, error) {
 		Body:      body,
 		Ctx:       r.Ctx,
 		Headers:   &http.Header{},
+		Host:      r.Host,
 		ID:        atomic.AddUint32(&r.collector.requestCount, 1),
 		collector: r.collector,
 	}, nil
@@ -178,6 +182,7 @@ func (r *Request) Marshal() ([]byte, error) {
 	}
 	sr := &serializableRequest{
 		URL:    r.URL.String(),
+		Host:   r.Host,
 		Method: r.Method,
 		Depth:  r.Depth,
 		Body:   body,


### PR DESCRIPTION
Fixes #564

This PR adds support for passing in custom HTTP headers for the crawler to use, and overriding the `Host` HTTP header. This can be useful when attempting to crawl an IP address while targeting a specific virtual host used in the web server on that IP address.