### PR TITLE
Add GitHub issue templates and nudge questions to Stack Overflow

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,2 +1,0 @@
-<!-- Love colly? Please consider supporting our collective:
-👉  https://opencollective.com/colly/donate -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,15 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+Remember to include a code sample that reproduces the bug, if possible.
+
+Love colly? Please consider supporting our collective:
+👉  https://opencollective.com/colly/donate
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question
+    url: https://stackoverflow.com/
+    about: Questions should go to Stack Overflow. You can use go-colly tag.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+Love colly? Please consider supporting our collective:
+👉  https://opencollective.com/colly/donate
+-->


### PR DESCRIPTION
Add some simple templates for bug report/feature requests, and, more importantly, nudge questions to Stack Overflow.

How it looks like: https://github.com/WGH-/colly/issues/new/choose