### PR TITLE
Add fuzzer

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/
+WORKDIR colly
+COPY .clusterfuzzlite/build.sh $SRC/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eu
+
+go get github.com/AdamKorcz/go-118-fuzz-build/utils
+go get github.com/AdamKorcz/go-fuzz-headers
+compile_native_go_fuzzer github.com/gocolly/colly/v2 FuzzHtmlElementUnmarshal FuzzHtmlElementUnmarshal
+

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: go

--- a/.github/workflows/cflite.yml
+++ b/.github/workflows/cflite.yml
@@ -1,0 +1,29 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**'
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: go
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 400
+        mode: 'code-change'
+        sanitizer: ${{ matrix.sanitizer }}

--- a/unmarshal_fuzz.go
+++ b/unmarshal_fuzz.go
@@ -1,0 +1,39 @@
+package colly
+
+import (
+	"bytes"
+	"testing"
+
+	fuzz "github.com/AdamKorcz/go-fuzz-headers"
+	"github.com/PuerkitoBio/goquery"
+)
+
+type info struct {
+	Text string `selector:"span"`
+}
+
+type object struct {
+	Info []*info `selector:"li.info"`
+}
+
+func FuzzHtmlElementUnmarshal(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		gfh := fuzz.NewConsumer(data)
+		e := &HTMLElement{}
+		err := gfh.GenerateStruct(e)
+		if err != nil {
+			return
+		}
+		d2, err := gfh.GetBytes()
+		if err != nil {
+			return
+		}
+		doc, err := goquery.NewDocumentFromReader(bytes.NewBuffer(d2))
+		if err != nil {
+			return
+		}
+		e.DOM = doc.First()
+		o := object{}
+		e.Unmarshal(&o)
+	})
+}


### PR DESCRIPTION
This PR adds [ClusterfuzzLite](https://google.github.io/clusterfuzzlite/) and a fuzzer for the HTML unmarshalling. 

ClusterfuzzLite will run fuzzers in the CI when PRs are made. It can be extended beyond this PR with code coverage and batch fuzzing: https://google.github.io/clusterfuzzlite/running-clusterfuzzlite/github-actions/

Signed-off-by: AdamKorcz <Adam@adalogics.com>