### PR TITLE
Fix data races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           OUT="$(gofmt -l -d ./)"; test -z "$OUT" || (echo "$OUT" && return 1)
           golint -set_exit_status
           go vet -v ./...
-          go test -race -v -coverprofile=coverage.txt -covermode=atomic ./
+          go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
 
   build:
     name: Build ${{matrix.go}}

--- a/colly_test.go
+++ b/colly_test.go
@@ -918,6 +918,19 @@ func TestRedirect(t *testing.T) {
 	c.Visit(ts.URL + "/redirect")
 }
 
+func TestIssue594(t *testing.T) {
+	// This is a regression test for a data race bug. There's no
+	// assertions because it's meant to be used with race detector
+	ts := newTestServer()
+	defer ts.Close()
+
+	c := NewCollector()
+	// if timeout is set, this bug is not triggered
+	c.SetClient(&http.Client{Timeout: 0 * time.Second})
+
+	c.Visit(ts.URL)
+}
+
 func TestRedirectWithDisallowedURLs(t *testing.T) {
 	ts := newTestServer()
 	defer ts.Close()


### PR DESCRIPTION
Closes #594

Also fixes a data race bug in tests, and enables CI testing of `./queue` sub-package which was accidentally left out.