### PR TITLE
Add mtnmunuklu/lescatit to the list of projects using Colly

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Below is a list of public, open source projects that use Colly:
 -   [docker-slim/docker-slim](https://github.com/docker-slim/docker-slim) Optimize your Docker containers to make them smaller and better.
 -   [seversky/gachifinder](https://github.com/seversky/gachifinder) an agent for asynchronous scraping, parsing and writing to some storages(elasticsearch for now)
 -   [eval-exec/goodreads](https://github.com/eval-exec/goodreads) crawl all tags and all pages of quotes from goodreads.
+-   [mtnmunuklu/lescatit](https://github.com/mtnmunuklu/lescatit) crawl and categorize URL addresses.
 
 If you are using Colly in a project please send a pull request to add it to the list.
 


### PR DESCRIPTION
### Summary of the Pull Request

Add mtnmunuklu/lescatit to the list of projects using Colly

### Detailed Description of the Pull Request / Additional Comments

This pull request adds the project "mtnmunuklu/lescatit" to the list of public, open-source projects that use Colly in the README file. This project is a web scraper that crawls and categorizes URL addresses.

### Example Log Event

N/A

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

N/A
