### PR TITLE
Queue Depth functionality + Panic with Async

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -132,6 +132,10 @@ func (q *Queue) Size() (int, error) {
 // to perform requests. Run blocks while the queue has active requests
 // The given Storage must not be used directly while Run blocks.
 func (q *Queue) Run(c *colly.Collector) error {
+	if c.Async {
+		// Async causes Queue crawling to silently fail, since all requests finish "Instantly"
+		panic("Cannot run Async collector in Queue!")
+	}
 	q.mut.Lock()
 	if q.wake != nil && q.running == true {
 		q.mut.Unlock()

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -90,6 +90,7 @@ func (q *Queue) AddURL(URL string) error {
 	r := &colly.Request{
 		URL:    u2,
 		Method: "GET",
+		Depth:  1,
 	}
 	d, err := r.Marshal()
 	if err != nil {

--- a/request.go
+++ b/request.go
@@ -158,7 +158,7 @@ func (r *Request) Retry() error {
 
 // Do submits the request
 func (r *Request) Do() error {
-	return r.collector.scrape(r.URL.String(), r.Method, r.Depth, r.Body, r.Ctx, *r.Headers, !r.collector.AllowURLRevisit)
+	return r.collector.scrape(r.URL.String(), r.Method, r.Depth+1, r.Body, r.Ctx, *r.Headers, !r.collector.AllowURLRevisit)
 }
 
 // Marshal serializes the Request


### PR DESCRIPTION
### Description

This pull request adds support for Depth in Queue and adds a panic when attempting to use Async with Queue, as they are incompatible. The changes ensure that MaxDepth works as expected when using Queues.

I had to figure out by trial and error that Async caused my Queue based crawler to instantly finish since it thought the returned promises were 'completed' requests.

### Changes Made

1. Added a default value for `Depth` for Requests made in `AddURL`.
2. Implemented a check in the `AddRequest` method to increase the depth for each nested request.
3. Added a panic in the `Queue.Run` method to prevent users from using Async with the Queue, as it's not supported.

### Checklist

- [x] Added unit tests for change

Please let me know if you require any changes to this Pull Request!
And if there's any interest I did make a `UniqueInMemoryQueueStorage` struct in my project that only stores non duplicate entries within the Queue.

Thank you!
