### PR TITLE
Replaced deprecated io/ioutil package with proper implementations of …

### DIFF
--- a/_examples/factba.se/factbase.go
+++ b/_examples/factba.se/factbase.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	"github.com/gocolly/colly/v2"
@@ -45,7 +45,7 @@ func main() {
 		if err != nil {
 			return
 		}
-		ioutil.WriteFile(colly.SanitizeFileName(e.Request.Ctx.Get("date")+"_"+e.Request.Ctx.Get("slug"))+".json", jsonData, 0644)
+		os.WriteFile(colly.SanitizeFileName(e.Request.Ctx.Get("date")+"_"+e.Request.Ctx.Get("slug"))+".json", jsonData, 0644)
 	})
 
 	stop := false

--- a/_examples/multipart/multipart.go
+++ b/_examples/multipart/multipart.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -14,7 +14,7 @@ func generateFormData() map[string][]byte {
 	f, _ := os.Open("gocolly.jpg")
 	defer f.Close()
 
-	imgData, _ := ioutil.ReadAll(f)
+	imgData, _ := io.ReadAll(f)
 
 	return map[string][]byte{
 		"firstname": []byte("one"),

--- a/http_backend.go
+++ b/http_backend.go
@@ -19,7 +19,6 @@ import (
 	"encoding/gob"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -209,7 +208,7 @@ func (h *httpBackend) Do(request *http.Request, bodySize int, checkHeadersFunc c
 		}
 		defer bodyReader.(*gzip.Reader).Close()
 	}
-	body, err := ioutil.ReadAll(bodyReader)
+	body, err := io.ReadAll(bodyReader)
 	if err != nil {
 		return nil, err
 	}

--- a/request.go
+++ b/request.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -173,7 +172,7 @@ func (r *Request) Marshal() ([]byte, error) {
 	var err error
 	var body []byte
 	if r.Body != nil {
-		body, err = ioutil.ReadAll(r.Body)
+		body, err = io.ReadAll(r.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/response.go
+++ b/response.go
@@ -17,9 +17,10 @@ package colly
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/saintfish/chardet"
@@ -45,7 +46,7 @@ type Response struct {
 
 // Save writes response body to disk
 func (r *Response) Save(fileName string) error {
-	return ioutil.WriteFile(fileName, r.Body, 0644)
+	return os.WriteFile(fileName, r.Body, 0644)
 }
 
 // FileName returns the sanitized file name parsed from "Content-Disposition"
@@ -111,5 +112,5 @@ func encodeBytes(b []byte, contentType string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }


### PR DESCRIPTION
…io/os packages.

As of Go v1.16, the io/ioutil package has been deprecated and replaced with io and os implementations. https://go.dev/doc/go1.16#ioutil