### PR TITLE
Fix Bug: retry scrape will lost POST requestData

### DIFF
--- a/request.go
+++ b/request.go
@@ -152,6 +152,9 @@ func (r *Request) PostMultipart(URL string, requestData map[string][]byte) error
 // Retry submits HTTP request again with the same parameters
 func (r *Request) Retry() error {
 	r.Headers.Del("Cookie")
+	if _, ok := r.Body.(io.ReadSeeker); r.Body != nil && !ok {
+		return ErrRetryBodyUnseekable
+	}
 	return r.collector.scrape(r.URL.String(), r.Method, r.Depth, r.Body, r.Ctx, *r.Headers, false)
 }
 


### PR DESCRIPTION
when retry scrape
requestData will loss in http.NewRequest

so Seek requestData before scrape.NewRequest

```
req.ContentLength  always 0 and

if req.GetBody != nil && req.ContentLength == 0 {
			req.Body = NoBody
			req.GetBody = func() (io.ReadCloser, error) { return NoBody, nil }
		}
```