### PR TITLE
doc: mention that OnScraped executes after OnHTML and OnXML

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -989,8 +989,8 @@ func (c *Collector) OnError(f ErrorCallback) {
 	c.lock.Unlock()
 }
 
-// OnScraped registers a function. Function will be executed after
-// OnHTML, as a final part of the scraping.
+// OnScraped registers a function that will be executed as the final part of
+// the scraping, after OnHTML and OnXML have finished.
 func (c *Collector) OnScraped(f ScrapedCallback) {
 	c.lock.Lock()
 	if c.scrapedCallbacks == nil {


### PR DESCRIPTION
In my project, I have `OnHTML` and `OnXML` callbacks, and I got confused when I read in the documentation that `OnScraped` would be executed after `OnHTML`. To figure out what would happen with `OnXML`, I had to dive into the source code.

This PR makes the `OnScraped` description a little clearer.