### PR TITLE
fix #835: calling a callback detach while executing a callback might cause callbacks to be skipped or executed twice

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,7 @@
+{
+    // Verwendet IntelliSense zum Ermitteln möglicher Attribute.
+    // Zeigen Sie auf vorhandene Attribute, um die zugehörigen Beschreibungen anzuzeigen.
+    // Weitere Informationen finden Sie unter https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": []
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,0 @@
-{
-    // Verwendet IntelliSense zum Ermitteln möglicher Attribute.
-    // Zeigen Sie auf vorhandene Attribute, um die zugehörigen Beschreibungen anzuzeigen.
-    // Weitere Informationen finden Sie unter https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": []
-}

--- a/colly.go
+++ b/colly.go
@@ -186,18 +186,10 @@ type htmlCallbackContainer struct {
 	active   atomic.Bool
 }
 
-func (c *htmlCallbackContainer) init() {
-	c.active.Store(true)
-}
-
 type xmlCallbackContainer struct {
 	Query    string
 	Function XMLCallback
 	active   atomic.Bool
-}
-
-func (c *xmlCallbackContainer) init() {
-	c.active.Store(true)
 }
 
 type cookieJarSerializer struct {
@@ -962,7 +954,7 @@ func (c *Collector) OnHTML(goquerySelector string, f HTMLCallback) {
 		Selector: goquerySelector,
 		Function: f,
 	}
-	cc.init()
+	cc.active.Store(true)
 	c.htmlCallbacks = append(c.htmlCallbacks, cc)
 	c.lock.Unlock()
 }
@@ -979,7 +971,7 @@ func (c *Collector) OnXML(xpathQuery string, f XMLCallback) {
 		Query:    xpathQuery,
 		Function: f,
 	}
-	cc.init()
+	cc.active.Store(true)
 	c.xmlCallbacks = append(c.xmlCallbacks, cc)
 	c.lock.Unlock()
 }

--- a/colly.go
+++ b/colly.go
@@ -183,11 +183,21 @@ func (e *AlreadyVisitedError) Error() string {
 type htmlCallbackContainer struct {
 	Selector string
 	Function HTMLCallback
+	active   atomic.Bool
+}
+
+func (c *htmlCallbackContainer) init() {
+	c.active.Store(true)
 }
 
 type xmlCallbackContainer struct {
 	Query    string
 	Function XMLCallback
+	active   atomic.Bool
+}
+
+func (c *xmlCallbackContainer) init() {
+	c.active.Store(true)
 }
 
 type cookieJarSerializer struct {
@@ -948,10 +958,12 @@ func (c *Collector) OnHTML(goquerySelector string, f HTMLCallback) {
 	if c.htmlCallbacks == nil {
 		c.htmlCallbacks = make([]*htmlCallbackContainer, 0, 4)
 	}
-	c.htmlCallbacks = append(c.htmlCallbacks, &htmlCallbackContainer{
+	cc := &htmlCallbackContainer{
 		Selector: goquerySelector,
 		Function: f,
-	})
+	}
+	cc.init()
+	c.htmlCallbacks = append(c.htmlCallbacks, cc)
 	c.lock.Unlock()
 }
 
@@ -963,43 +975,37 @@ func (c *Collector) OnXML(xpathQuery string, f XMLCallback) {
 	if c.xmlCallbacks == nil {
 		c.xmlCallbacks = make([]*xmlCallbackContainer, 0, 4)
 	}
-	c.xmlCallbacks = append(c.xmlCallbacks, &xmlCallbackContainer{
+	cc := &xmlCallbackContainer{
 		Query:    xpathQuery,
 		Function: f,
-	})
+	}
+	cc.init()
+	c.xmlCallbacks = append(c.xmlCallbacks, cc)
 	c.lock.Unlock()
 }
 
 // OnHTMLDetach deregister a function. Function will not be execute after detached
 func (c *Collector) OnHTMLDetach(goquerySelector string) {
 	c.lock.Lock()
-	deleteIdx := -1
-	for i, cc := range c.htmlCallbacks {
+	defer c.lock.Unlock()
+
+	for _, cc := range c.htmlCallbacks {
 		if cc.Selector == goquerySelector {
-			deleteIdx = i
-			break
+			cc.active.Store(false)
 		}
 	}
-	if deleteIdx != -1 {
-		c.htmlCallbacks = append(c.htmlCallbacks[:deleteIdx], c.htmlCallbacks[deleteIdx+1:]...)
-	}
-	c.lock.Unlock()
 }
 
 // OnXMLDetach deregister a function. Function will not be execute after detached
 func (c *Collector) OnXMLDetach(xpathQuery string) {
 	c.lock.Lock()
-	deleteIdx := -1
-	for i, cc := range c.xmlCallbacks {
+	defer c.lock.Unlock()
+
+	for _, cc := range c.xmlCallbacks {
 		if cc.Query == xpathQuery {
-			deleteIdx = i
-			break
+			cc.active.Store(false)
 		}
 	}
-	if deleteIdx != -1 {
-		c.xmlCallbacks = append(c.xmlCallbacks[:deleteIdx], c.xmlCallbacks[deleteIdx+1:]...)
-	}
-	c.lock.Unlock()
 }
 
 // OnError registers a function. Function will be executed if an error
@@ -1177,6 +1183,9 @@ func (c *Collector) handleOnHTML(resp *Response) error {
 
 	}
 	for _, cc := range c.htmlCallbacks {
+		if !cc.active.Load() {
+			continue
+		}
 		i := 0
 		doc.Find(cc.Selector).Each(func(_ int, s *goquery.Selection) {
 			for _, n := range s.Nodes {
@@ -1223,6 +1232,9 @@ func (c *Collector) handleOnXML(resp *Response) error {
 		}
 
 		for _, cc := range c.xmlCallbacks {
+			if !cc.active.Load() {
+				continue
+			}
 			for _, n := range htmlquery.Find(doc, cc.Query) {
 				e := NewXMLElementFromHTMLNode(resp, n)
 				if c.debugger != nil {
@@ -1241,6 +1253,9 @@ func (c *Collector) handleOnXML(resp *Response) error {
 		}
 
 		for _, cc := range c.xmlCallbacks {
+			if !cc.active.Load() {
+				continue
+			}
 			xmlquery.FindEach(doc, cc.Query, func(i int, n *xmlquery.Node) {
 				e := NewXMLElementFromXMLNode(resp, n)
 				if c.debugger != nil {
@@ -1287,6 +1302,29 @@ func (c *Collector) handleOnError(response *Response, err error, request *Reques
 	return err
 }
 
+func (c *Collector) cleanupCallbacks() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Clean HTML callbacks
+	activeHTML := make([]*htmlCallbackContainer, 0, len(c.htmlCallbacks))
+	for _, cc := range c.htmlCallbacks {
+		if cc.active.Load() {
+			activeHTML = append(activeHTML, cc)
+		}
+	}
+	c.htmlCallbacks = activeHTML
+
+	// Clean XML callbacks
+	activeXML := make([]*xmlCallbackContainer, 0, len(c.xmlCallbacks))
+	for _, cc := range c.xmlCallbacks {
+		if cc.active.Load() {
+			activeXML = append(activeXML, cc)
+		}
+	}
+	c.xmlCallbacks = activeXML
+}
+
 func (c *Collector) handleOnScraped(r *Response) {
 	if c.debugger != nil {
 		c.debugger.Event(createEvent("scraped", r.Request.ID, c.ID, map[string]string{
@@ -1296,6 +1334,9 @@ func (c *Collector) handleOnScraped(r *Response) {
 	for _, f := range c.scrapedCallbacks {
 		f(r)
 	}
+
+	// Cleanup inactive callbacks after processing each response
+	c.cleanupCallbacks()
 }
 
 // Limit adds a new LimitRule to the collector

--- a/colly_test.go
+++ b/colly_test.go
@@ -46,6 +46,7 @@ var callbackTestHTML = []byte(`
 <div id="firstElem">First</div>
 <div id="secondElem">Second</div>
 <div id="thirdElem">Third</div>
+<div id="fourthElem">Fourth</div>
 </body>
 </html>
 `)
@@ -1762,7 +1763,7 @@ func TestCallbackDetachment(t *testing.T) {
 	c := NewCollector()
 	c.AllowURLRevisit = true
 
-	var executions [3]int // tracks callback executions for each element
+	var executions [4]int // tracks number of executions of each callback
 
 	c.OnHTML("#firstElem", func(e *HTMLElement) {
 		executions[0]++
@@ -1776,6 +1777,10 @@ func TestCallbackDetachment(t *testing.T) {
 
 	c.OnHTML("#thirdElem", func(e *HTMLElement) {
 		executions[2]++
+	})
+
+	c.OnHTML("#fourthElem", func(e *HTMLElement) {
+		executions[3]++
 	})
 
 	// First visit - all callbacks should execute
@@ -1793,6 +1798,9 @@ func TestCallbackDetachment(t *testing.T) {
 	}
 	if executions[2] != 2 {
 		t.Errorf("thirdElem callback executed %d times, expected 2", executions[2])
+	}
+	if executions[2] != 2 {
+		t.Errorf("fourthElem callback executed %d times, expected 2", executions[2])
 	}
 }
 

--- a/colly_test.go
+++ b/colly_test.go
@@ -46,7 +46,6 @@ var callbackTestHTML = []byte(`
 <div id="firstElem">First</div>
 <div id="secondElem">Second</div>
 <div id="thirdElem">Third</div>
-<div id="fourthElem">Fourth</div>
 </body>
 </html>
 `)
@@ -1763,44 +1762,34 @@ func TestCallbackDetachment(t *testing.T) {
 	c := NewCollector()
 	c.AllowURLRevisit = true
 
-	var executions [4]int // tracks number of executions of each callback
+	var executions [3]int // tracks number of executions of each callback
 
 	c.OnHTML("#firstElem", func(e *HTMLElement) {
 		executions[0]++
+		// Detach this callback after first execution
+		c.OnHTMLDetach("#firstElem")
 	})
-
 	c.OnHTML("#secondElem", func(e *HTMLElement) {
 		executions[1]++
-		// Detach this callback after first execution
-		c.OnHTMLDetach("#secondElem")
 	})
-
 	c.OnHTML("#thirdElem", func(e *HTMLElement) {
 		executions[2]++
 	})
 
-	c.OnHTML("#fourthElem", func(e *HTMLElement) {
-		executions[3]++
-	})
-
 	// First visit - all callbacks should execute
 	c.Visit(ts.URL + "/callback_test")
-
-	// Second visit - second callback should NOT execute
+	// Second visit - first callback should NOT execute
 	c.Visit(ts.URL + "/callback_test")
 
 	// Verify callback counts
-	if executions[0] != 2 {
-		t.Errorf("firstElem callback executed %d times, expected 2", executions[0])
+	if executions[0] != 1 {
+		t.Errorf("firstElem callback executed %d times, expected 1", executions[0])
 	}
-	if executions[1] != 1 {
-		t.Errorf("secondElem callback executed %d times, expected 1", executions[1])
+	if executions[1] != 2 {
+		t.Errorf("secondElem callback executed %d times, expected 2", executions[1])
 	}
 	if executions[2] != 2 {
 		t.Errorf("thirdElem callback executed %d times, expected 2", executions[2])
-	}
-	if executions[2] != 2 {
-		t.Errorf("fourthElem callback executed %d times, expected 2", executions[2])
 	}
 }
 


### PR DESCRIPTION
I've added a fix for the issue #835 of calling `html` and `xml` detaches while inside a `html` or `xml` callback. Previously this caused the slice to be modified while iterating over it, which might cause other callbacks to be skipped or to be executed twice (see [this playground](https://go.dev/play/p/5MDOu-Eo5LQ) for a short demo of a bug when modifying a slice while ranging over it). 

This PR changes the callback execution logic to introduce a parameter `active` and track which callbacks have `active == true` and only execute those. Calling a detach will set `active` to `false` for the callback, at a later step we remove all inactive callbacks.

This PR also adds a test for this issue.