### PR TITLE
docs: correct comment in SetProxyFunc to refer to *http.Transport

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -1078,7 +1078,7 @@ func (c *Collector) SetProxy(proxyURL string) error {
 // SetProxyFunc sets a custom proxy setter/switcher function.
 // See built-in ProxyFuncs for more details.
 // This method overrides the previously used http.Transport
-// if the type of the transport is not http.RoundTripper.
+// if the type of the transport is not *http.Transport.
 // The proxy type is determined by the URL scheme. "http"
 // and "socks5" are supported. If the scheme is empty,
 // "http" is assumed.


### PR DESCRIPTION
### What
The comment above Collector.SetProxyFunc said it only overrides the transport
if it “is not http.RoundTripper”, but the code actually looks for *http.Transport.
This PR updates the comment to correctly state that we override when the
existing Transport is not of type *http.Transport.

### Why
- Keeps documentation in sync with implementation.
- Avoids confusion for future contributors reading the code.

### How to test
This is purely a comment change; no behavior is affected.