### PR TITLE
Add cache expiration option

### DIFF
--- a/_examples/coursera_courses/coursera_courses.go
+++ b/_examples/coursera_courses/coursera_courses.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/gocolly/colly/v2"
 )
@@ -38,6 +39,8 @@ func main() {
 		// Cache responses to prevent multiple download of pages
 		// even if the collector is restarted
 		colly.CacheDir("./coursera_cache"),
+		// Cached responses older than the specified duration will be refreshed
+		colly.CacheExpiration(24*time.Hour),
 	)
 
 	// Create another collector to scrape course details

--- a/colly_test.go
+++ b/colly_test.go
@@ -401,6 +401,19 @@ var newCollectorTests = map[string]func(*testing.T){
 			}
 		}
 	},
+	"CacheExpiration": func(t *testing.T) {
+		for _, d := range []time.Duration{
+			5 * time.Second,
+			10 * time.Minute,
+			0,
+		} {
+			c := NewCollector(CacheExpiration(d))
+
+			if got, want := c.CacheExpiration, d; got != want {
+				t.Fatalf("c.CacheExpiration = %v, want %v", got, want)
+			}
+		}
+	},
 	"IgnoreRobotsTxt": func(t *testing.T) {
 		c := NewCollector(IgnoreRobotsTxt())
 

--- a/http_backend.go
+++ b/http_backend.go
@@ -18,7 +18,6 @@ import (
 	"crypto/sha1"
 	"encoding/gob"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"math/rand"
 	"net/http"
@@ -164,7 +163,6 @@ func (h *httpBackend) Cache(request *http.Request, bodySize int, checkHeadersFun
 	}
 	file, err := os.Create(filename + "~")
 	if err != nil {
-		fmt.Println("made file", file)
 		return resp, err
 	}
 	if err := gob.NewEncoder(file).Encode(resp); err != nil {


### PR DESCRIPTION
Resolves #834.

This pull request adds support for a new CacheExpiration option to the Collector struct, allowing users to set a duration after which cached responses are considered stale and will be refreshed.
