### PR TITLE
fix: Fix incorrect JSON tag

### DIFF
--- a/_examples/instagram/instagram.go
+++ b/_examples/instagram/instagram.go
@@ -44,7 +44,7 @@ type mainPageData struct {
 									Width  int `json:"width"`
 									Height int `json:"height"`
 								} `json:"dimensions"`
-							} `json::node"`
+							} `json:node"`
 						} `json:"edges"`
 						PageInfo pageInfo `json:"page_info"`
 					} `json:"edge_owner_to_timeline_media"`


### PR DESCRIPTION
An extra colon in the JSON tag can cause parsing errors.