### PR TITLE
CacheExpiration should be copied when cloned

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -1422,6 +1422,7 @@ func (c *Collector) Clone() *Collector {
 		AllowedDomains:         c.AllowedDomains,
 		AllowURLRevisit:        c.AllowURLRevisit,
 		CacheDir:               c.CacheDir,
+		CacheExpiration:	c.CacheExpiration,
 		DetectCharset:          c.DetectCharset,
 		DisallowedDomains:      c.DisallowedDomains,
 		ID:                     atomic.AddUint32(&collectorCounter, 1),


### PR DESCRIPTION
Makes sense to me that CacheExpiration should be copied when you copy a collector