### PR TITLE
refactor: use the built-in max to simplify the code

### DIFF
--- a/http_backend.go
+++ b/http_backend.go
@@ -66,11 +66,7 @@ type LimitRule struct {
 
 // Init initializes the private members of LimitRule
 func (r *LimitRule) Init() error {
-	waitChanSize := 1
-	if r.Parallelism > 1 {
-		waitChanSize = r.Parallelism
-	}
-	r.waitChan = make(chan bool, waitChanSize)
+	r.waitChan = make(chan bool, max(r.Parallelism, 1))
 	hasPattern := false
 	if r.DomainRegexp != "" {
 		c, err := regexp.Compile(r.DomainRegexp)


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.