### PR TITLE
Refactor parseSettingsFromEnv to avoid magic numbers

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -214,6 +214,9 @@ const (
 	CheckRevisitKey
 )
 
+// The prefix for environment variables of Colly settings
+const EnvVariablePrefix = "COLLY_"
+
 var (
 	// ErrForbiddenDomain is the error thrown if visiting
 	// a domain which is not allowed in AllowedDomains
@@ -1507,10 +1510,10 @@ func (c *Collector) checkRedirectFunc() func(req *http.Request, via []*http.Requ
 
 func (c *Collector) parseSettingsFromEnv() {
 	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, "COLLY_") {
+		if !strings.HasPrefix(e, EnvVariablePrefix) {
 			continue
 		}
-		pair := strings.SplitN(e[6:], "=", 2)
+		pair := strings.SplitN(e[len(EnvVariablePrefix):], "=", 2)
 		if f, ok := envMap[pair[0]]; ok {
 			f(c, pair[1])
 		} else {

--- a/colly.go
+++ b/colly.go
@@ -215,7 +215,7 @@ const (
 )
 
 // The prefix for environment variables of Colly settings
-const EnvVariablePrefix = "COLLY_"
+const envVariablePrefix = "COLLY_"
 
 var (
 	// ErrForbiddenDomain is the error thrown if visiting
@@ -1510,10 +1510,10 @@ func (c *Collector) checkRedirectFunc() func(req *http.Request, via []*http.Requ
 
 func (c *Collector) parseSettingsFromEnv() {
 	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, EnvVariablePrefix) {
+		if !strings.HasPrefix(e, envVariablePrefix) {
 			continue
 		}
-		pair := strings.SplitN(e[len(EnvVariablePrefix):], "=", 2)
+		pair := strings.SplitN(e[len(envVariablePrefix):], "=", 2)
 		if f, ok := envMap[pair[0]]; ok {
 			f(c, pair[1])
 		} else {


### PR DESCRIPTION
This PR simply refactors the parseSettingsFromEnv method in the collector by introducing a constant string for the environment variable prefix and removing magic numbers from its implementation.