### PR TITLE
Security: Panic in HTTP handler causes denial of service in WebDebugger

### DIFF
--- a/debug/webdebugger.go
+++ b/debug/webdebugger.go
@@ -147,7 +147,9 @@ func (w *WebDebugger) statusHandler(wr http.ResponseWriter, r *http.Request) {
 	jsonData, err := json.MarshalIndent(w, "", "  ")
 	w.Unlock()
 	if err != nil {
-		panic(err)
+		http.Error(wr, "internal server error", http.StatusInternalServerError)
+		log.Println("Error marshaling status JSON:", err)
+		return
 	}
 	wr.Write(jsonData)
 }


### PR DESCRIPTION
## Problem

The `statusHandler` method calls `panic(err)` when JSON marshaling fails. Since this runs inside an HTTP handler, it will crash the entire process (or at minimum the goroutine serving the request if a recovery middleware were present, which there isn't). An attacker who can trigger a marshaling error can cause a denial of service.

**Severity**: `medium`
**File**: `debug/webdebugger.go`

## Solution

Replace `panic(err)` with proper error handling: `http.Error(wr, "internal server error", http.StatusInternalServerError)` and log the error.

## Changes

- `debug/webdebugger.go` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
