### PR TITLE
fix: use precise XML MIME type matching to avoid parsing .xlsx files

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -1246,8 +1246,14 @@ func (c *Collector) handleOnXML(resp *Response) error {
 		return nil
 	}
 	contentType := strings.ToLower(resp.Headers.Get("Content-Type"))
+	// Parse the media type without parameters (e.g. charset)
+	mediatype, _, _ := strings.Cut(contentType, ";")
+	mediatype = strings.TrimSpace(mediatype)
 	isXMLFile := strings.HasSuffix(strings.ToLower(resp.Request.URL.Path), ".xml") || strings.HasSuffix(strings.ToLower(resp.Request.URL.Path), ".xml.gz")
-	if !strings.Contains(contentType, "html") && (!strings.Contains(contentType, "xml") && !isXMLFile) {
+	// Check for actual XML media types: text/xml, application/xml, or *+xml (e.g. application/rss+xml).
+	// Do NOT match types that merely contain "xml" in the name (e.g. .xlsx MIME types).
+	isXMLContent := mediatype == "text/xml" || mediatype == "application/xml" || strings.HasSuffix(mediatype, "+xml")
+	if !strings.Contains(contentType, "html") && !isXMLContent && !isXMLFile {
 		return nil
 	}
 
@@ -1284,7 +1290,7 @@ func (c *Collector) handleOnXML(resp *Response) error {
 				cc.Function(e)
 			}
 		}
-	} else if strings.Contains(contentType, "xml") || isXMLFile {
+	} else if isXMLContent || isXMLFile {
 		doc, err := xmlquery.Parse(bytes.NewBuffer(resp.Body))
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes #790

## Problem

`handleOnXML` uses `strings.Contains(contentType, "xml")` to detect XML responses. This incorrectly matches OOXML MIME types like:

- `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` (.xlsx)
- `application/vnd.openxmlformats-officedocument.wordprocessingml.document` (.docx)

These are ZIP archives, not XML, causing `xmlquery.Parse()` to fail with errors like `encoding/xml.SyntaxError`.

## Fix

Replace the substring match with precise MIME type checks per [RFC 7303](https://datatracker.ietf.org/doc/html/rfc7303):

- `text/xml`
- `application/xml`
- `*+xml` suffix (e.g. `application/rss+xml`, `application/atom+xml`)

This correctly excludes OOXML types while still matching all standard XML content types.