### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/cmd/colly/colly.go
+++ b/cmd/colly/colly.go
@@ -99,7 +99,7 @@ func main() {
 				scraper.WriteString("}\n")
 			}
 			if len(*callbacks) > 0 {
-				for _, c := range strings.Split(*callbacks, ",") {
+				for c := range strings.SplitSeq(*callbacks, ",") {
 					switch c {
 					case "html":
 						scraper.WriteString(htmlCallbackTemplate)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -110,7 +110,7 @@ func StringifyCookies(cookies []*http.Cookie) string {
 // UnstringifyCookies deserializes a cookie string to http.Cookies
 func UnstringifyCookies(s string) []*http.Cookie {
 	h := http.Header{}
-	for _, c := range strings.Split(s, "\n") {
+	for c := range strings.SplitSeq(s, "\n") {
 		h.Add("Set-Cookie", c)
 	}
 	r := http.Response{Header: h}


### PR DESCRIPTION
strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901