### PR TITLE
drop deprecated rand.Seed call in httpBackend.Init

### DIFF
--- a/http_backend.go
+++ b/http_backend.go
@@ -92,7 +92,6 @@ func (r *LimitRule) Init() error {
 }
 
 func (h *httpBackend) Init(jar http.CookieJar) {
-	rand.Seed(time.Now().UnixNano())
 	h.Client = &http.Client{
 		Jar:     jar,
 		Timeout: 10 * time.Second,


### PR DESCRIPTION
Closes #820.

\`math/rand\` self-seeds with a random value since Go 1.20 and the deprecation note on \`rand.Seed\` is pretty explicit. go.mod already requires go 1.24, so the call in \`httpBackend.Init\` is dead weight and gopls flags it as deprecated.