### PR TITLE
queue: don't block AddRequest after Run has returned

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -110,7 +110,10 @@ func (q *Queue) AddRequest(r *colly.Request) error {
 	if err != nil {
 		return err
 	}
-	q.wake <- struct{}{}
+	select {
+	case q.wake <- struct{}{}:
+	default:
+	}
 	return nil
 }
 
@@ -136,7 +139,7 @@ func (q *Queue) Run(c *colly.Collector) error {
 		q.mut.Unlock()
 		panic("cannot call duplicate Queue.Run")
 	}
-	q.wake = make(chan struct{})
+	q.wake = make(chan struct{}, 1)
 	q.running = true
 	q.mut.Unlock()
 

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -75,6 +75,36 @@ func TestQueue(t *testing.T) {
 	}
 }
 
+func TestAddRequestAfterRunReturned(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(serverHandler))
+	defer server.Close()
+
+	q, err := New(1, &InMemoryQueueStorage{MaxSize: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := colly.NewCollector()
+	if err := q.AddURL(server.URL + "/delay?t=0s"); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Run(c); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- q.AddURL(server.URL + "/delay?t=0s")
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("AddURL after Run returned: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("AddURL blocked after Run returned (see #740)")
+	}
+}
+
 func serverHandler(w http.ResponseWriter, req *http.Request) {
 	if !serverRoute(w, req) {
 		shutdown(w)


### PR DESCRIPTION
\`q.wake\` was an unbuffered channel and \`AddRequest\` sent to it directly. Once \`Run\` exits nobody reads \`q.wake\`, but \`q.wake\` is still non-nil so the wake-needed check still hits the send and blocks forever (one stuck goroutine per leftover \`AddRequest\` call). That's the scenario the issue describes.

Switched \`wake\` to a cap-1 buffered channel and made the send non-blocking. A signal is preserved while the loop is running (the buffer absorbs one until the loop's select reads it), and after the loop has exited the first \`AddRequest\` lands in the buffer and any subsequent send drops via \`default\` instead of hanging.

Regression test posts an \`AddURL\` after \`Run\` returns and fails if it doesn't come back within a second.

fixes #740