### PR TITLE
Fix Clone() so CheckRedirect closes over the clone, not the parent

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -1420,7 +1420,7 @@ func (c *Collector) Cookies(URL string) []*http.Cookie {
 // HTTP backend, robots.txt cache and cookie jar are shared
 // between collectors.
 func (c *Collector) Clone() *Collector {
-	return &Collector{
+	d := &Collector{
 		AllowedDomains:         c.AllowedDomains,
 		AllowURLRevisit:        c.AllowURLRevisit,
 		CacheDir:               c.CacheDir,
@@ -1455,6 +1455,19 @@ func (c *Collector) Clone() *Collector {
 		robotsMap:              c.robotsMap,
 		wg:                     &sync.WaitGroup{},
 	}
+	// The cloned collector must own its CheckRedirect function so that
+	// settings like AllowURLRevisit are read from the clone, not the
+	// parent.  We keep everything else (Transport, Jar, Timeout, …)
+	// shared by making a shallow copy of the parent's http.Client and
+	// replacing only CheckRedirect.
+	cloneClient := *c.backend.Client
+	cloneClient.CheckRedirect = d.checkRedirectFunc()
+	d.backend = &httpBackend{
+		LimitRules: c.backend.LimitRules,
+		Client:     &cloneClient,
+		lock:       c.backend.lock,
+	}
+	return d
 }
 
 func (c *Collector) checkRedirectFunc() func(req *http.Request, via []*http.Request) error {

--- a/colly_test.go
+++ b/colly_test.go
@@ -2259,9 +2259,14 @@ func TestCloneAllowURLRevisitIndependent(t *testing.T) {
 	redirectURL := ts.URL + "/redirect"
 	finalURL := ts.URL + "/redirected/"
 
-	visited := make(map[string]int)
+	requestCount := make(map[string]int)
 	clone.OnRequest(func(r *Request) {
-		visited[r.URL.String()]++
+		requestCount[r.URL.String()]++
+	})
+
+	responseCount := make(map[string]int)
+	clone.OnResponse(func(r *Response) {
+		responseCount[r.Request.URL.String()]++
 	})
 
 	// Visit the redirect URL twice; each visit should reach the final
@@ -2272,10 +2277,10 @@ func TestCloneAllowURLRevisitIndependent(t *testing.T) {
 		}
 	}
 
-	if visited[redirectURL] != 2 {
-		t.Errorf("redirect URL visited %d times, want 2", visited[redirectURL])
+	if requestCount[redirectURL] != 2 {
+		t.Errorf("redirect URL visited %d times, want 2", requestCount[redirectURL])
 	}
-	if visited[finalURL] != 2 {
-		t.Errorf("final URL visited %d times, want 2", visited[finalURL])
+	if responseCount[finalURL] != 2 {
+		t.Errorf("final URL visited %d times, want 2", responseCount[finalURL])
 	}
 }

--- a/colly_test.go
+++ b/colly_test.go
@@ -2236,3 +2236,46 @@ func TestLimitRuleClone(t *testing.T) {
 		t.Error("clone.Init() must not mutate the source's unexported state")
 	}
 }
+
+// TestCloneAllowURLRevisitIndependent verifies that AllowURLRevisit on a
+// cloned Collector is honoured independently of the parent Collector.
+//
+// Previously Clone() shared the parent's http.Client and therefore the
+// parent's CheckRedirect function, which closes over the parent collector.
+// A redirect on the clone would therefore evaluate the *parent's*
+// AllowURLRevisit field instead of the clone's, causing "already visited"
+// errors even when the clone set AllowURLRevisit = true.
+func TestCloneAllowURLRevisitIndependent(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	// Parent does NOT allow revisits.
+	parent := NewCollector()
+
+	// Clone DOES allow revisits.
+	clone := parent.Clone()
+	clone.AllowURLRevisit = true
+
+	redirectURL := ts.URL + "/redirect"
+	finalURL := ts.URL + "/redirected/"
+
+	visited := make(map[string]int)
+	clone.OnRequest(func(r *Request) {
+		visited[r.URL.String()]++
+	})
+
+	// Visit the redirect URL twice; each visit should reach the final
+	// destination without triggering an "already visited" error.
+	for i := 0; i < 2; i++ {
+		if err := clone.Visit(redirectURL); err != nil {
+			t.Fatalf("visit %d: unexpected error: %v", i+1, err)
+		}
+	}
+
+	if visited[redirectURL] != 2 {
+		t.Errorf("redirect URL visited %d times, want 2", visited[redirectURL])
+	}
+	if visited[finalURL] != 2 {
+		t.Errorf("final URL visited %d times, want 2", visited[finalURL])
+	}
+}


### PR DESCRIPTION
Fixes #875.

## What's wrong

`Clone()` shares the parent's `*httpBackend` (and therefore the same `*http.Client`). During `Init()`, the client's `CheckRedirect` is set to `c.checkRedirectFunc()`, a closure that captures the parent collector `c`. When a cloned collector follows a redirect, it calls the **parent's** redirect function, not the clone's.

Concretely, even if `clone.AllowURLRevisit = true`, the redirect check reads `parent.AllowURLRevisit` (which may be `false`), and the redirect fails with `AlreadyVisitedError`.

## Fix

Give the clone its own `http.Client` — a shallow copy of the parent's, with `CheckRedirect` replaced by `d.checkRedirectFunc()` (closing over the clone). The `Transport`, `Jar`, and `Timeout` are copied by the struct literal and still reference the same underlying objects, so connection-pool and cookie-jar sharing is preserved.

```go
cloneClient := *c.backend.Client
cloneClient.CheckRedirect = d.checkRedirectFunc()
d.backend = &httpBackend{
    LimitRules: c.backend.LimitRules,
    Client:     &cloneClient,
    lock:       c.backend.lock,
}
```

## Test

`TestCloneAllowURLRevisitIndependent` creates a parent with `AllowURLRevisit = false`, clones it and sets `AllowURLRevisit = true` on the clone, then visits a redirecting URL twice. Before this fix the second visit panicked with an `AlreadyVisitedError` on the redirect leg; after the fix both visits complete successfully.