### PR TITLE
docs: clarify request depth semantics

### DIFF
--- a/_examples/max_depth/max_depth.go
+++ b/_examples/max_depth/max_depth.go
@@ -9,9 +9,9 @@ import (
 func main() {
 	// Instantiate default collector
 	c := colly.NewCollector(
-		// MaxDepth is 1, so only the links on the scraped page
-		// is visited, and no further links are followed
-		colly.MaxDepth(1),
+		// MaxDepth is 2, so the start URL and links on its page
+		// are visited, and no further links are followed
+		colly.MaxDepth(2),
 	)
 
 	// On every a element which has href attribute call callback

--- a/_examples/parallel/parallel.go
+++ b/_examples/parallel/parallel.go
@@ -9,8 +9,8 @@ import (
 func main() {
 	// Instantiate default collector
 	c := colly.NewCollector(
-		// MaxDepth is 2, so only the links on the scraped page
-		// and links on those pages are visited
+		// MaxDepth is 2, so the start URL and links on its page
+		// are visited, and no further links are followed
 		colly.MaxDepth(2),
 		colly.Async(),
 	)

--- a/colly.go
+++ b/colly.go
@@ -58,7 +58,9 @@ type Collector struct {
 	UserAgent string
 	// Custom headers for the request
 	Headers *http.Header
-	// MaxDepth limits the recursion depth of visited URLs.
+	// MaxDepth limits the 1-based recursion depth of visited URLs.
+	// Direct Collector requests have depth 1, and requests made from another
+	// Request have their parent's depth plus 1.
 	// Set it to 0 for infinite recursion (default).
 	MaxDepth int
 	// AllowedDomains is a domain whitelist.
@@ -341,7 +343,7 @@ func Headers(headers map[string]string) CollectorOption {
 	}
 }
 
-// MaxDepth limits the recursion depth of visited URLs.
+// MaxDepth limits the 1-based recursion depth of visited URLs.
 func MaxDepth(depth int) CollectorOption {
 	return func(c *Collector) {
 		c.MaxDepth = depth

--- a/colly_test.go
+++ b/colly_test.go
@@ -1762,6 +1762,32 @@ func TestCollectorDepth(t *testing.T) {
 	}
 }
 
+func TestCollectorRequestDepthValues(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	c := NewCollector(MaxDepth(2), AllowURLRevisit())
+	var depths []int
+
+	c.OnResponse(func(resp *Response) {
+		depths = append(depths, resp.Request.Depth)
+		if len(depths) == 1 {
+			if err := resp.Request.Visit(ts.URL); err != nil {
+				t.Errorf("Failed to visit child request: %v", err)
+			}
+		}
+	})
+
+	if err := c.Visit(ts.URL); err != nil {
+		t.Fatalf("Failed to visit root request: %v", err)
+	}
+
+	expectedDepths := []int{1, 2}
+	if !reflect.DeepEqual(depths, expectedDepths) {
+		t.Fatalf("Invalid request depths: %v (expected %v)", depths, expectedDepths)
+	}
+}
+
 func TestCollectorRequests(t *testing.T) {
 	ts := newTestServer()
 	defer ts.Close()

--- a/request.go
+++ b/request.go
@@ -33,7 +33,9 @@ type Request struct {
 	Host string
 	// Ctx is a context between a Request and a Response
 	Ctx *Context
-	// Depth is the number of the parents of the request
+	// Depth is the 1-based depth of the request. Requests made directly
+	// through a Collector have depth 1, and requests made from another
+	// Request have their parent's depth plus 1.
 	Depth int
 	// Method is the HTTP method of the request
 	Method string


### PR DESCRIPTION
## Summary
- Document `Request.Depth` and `MaxDepth` as 1-based values.
- Update the max-depth examples so their comments match root depth 1 and child depth 2.
- Add a regression test for root and child request depth values.

Fixes #769

## Verification
- `go test . -run TestCollectorRequestDepthValues -count=1 -v`
- `go test ./... -count=1`
- `go test ./_examples/max_depth ./_examples/parallel`
- `git diff --check`