### PR TITLE
Fix queue AddRequest after Run returns

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -101,16 +101,18 @@ func (q *Queue) AddURL(URL string) error {
 // AddRequest adds a new Request to the queue
 func (q *Queue) AddRequest(r *colly.Request) error {
 	q.mut.Lock()
-	waken := q.wake != nil
+	wake := q.wake
 	q.mut.Unlock()
-	if !waken {
-		return q.storeRequest(r)
-	}
 	err := q.storeRequest(r)
 	if err != nil {
 		return err
 	}
-	q.wake <- struct{}{}
+	if wake != nil {
+		select {
+		case wake <- struct{}{}:
+		default:
+		}
+	}
 	return nil
 }
 
@@ -136,7 +138,7 @@ func (q *Queue) Run(c *colly.Collector) error {
 		q.mut.Unlock()
 		panic("cannot call duplicate Queue.Run")
 	}
-	q.wake = make(chan struct{})
+	q.wake = make(chan struct{}, 1)
 	q.running = true
 	q.mut.Unlock()
 
@@ -147,7 +149,12 @@ func (q *Queue) Run(c *colly.Collector) error {
 	}
 	go q.loop(c, requestc, complete, errc)
 	defer close(requestc)
-	return <-errc
+	err := <-errc
+	q.mut.Lock()
+	q.wake = nil
+	q.running = false
+	q.mut.Unlock()
+	return err
 }
 
 // Stop will stop the running queue

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -72,6 +73,45 @@ func TestQueue(t *testing.T) {
 		t.Fatalf("wrong Queue implementation: "+
 			"items = %d, requests = %d, success = %d, failure = %d",
 			items, requests, success, failure)
+	}
+}
+
+func TestAddRequestAfterRunReturns(t *testing.T) {
+	q, err := New(1, &InMemoryQueueStorage{MaxSize: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Run(colly.NewCollector()); err != nil {
+		t.Fatalf("Queue.Run() returned an error: %v", err)
+	}
+
+	u, err := url.Parse("http://example.test/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- q.AddRequest(&colly.Request{
+			URL:    u,
+			Method: "GET",
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("AddRequest() returned an error: %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("AddRequest() blocked after Queue.Run() returned")
+	}
+
+	size, err := q.Size()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != 1 {
+		t.Fatalf("queue size = %d, want 1", size)
 	}
 }
 


### PR DESCRIPTION
Fixes #740.

`Queue.Run` leaves the queue with no goroutine receiving from `q.wake` after it returns. A later `AddRequest` could store the request and then block forever on the unbuffered wake send.

This keeps wake notifications nonblocking and clears the wake channel before `Run` returns. The new regression test covers `AddRequest` after an empty run has completed.

Verification:

```text
go test ./queue -run 'Test(AddRequestAfterRunReturns|Queue)$' -count=1 -v
go test ./queue -run TestAddRequestAfterRunReturns -count=20
go test ./... -count=1
git diff --check origin/master...HEAD
```
