### PR TITLE
fix: report robots.txt fetch errors to OnError

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -234,6 +234,8 @@ var (
 	ErrNoURLFiltersMatch = errors.New("No URLFilters match")
 	// ErrRobotsTxtBlocked is the error type for robots.txt errors
 	ErrRobotsTxtBlocked = errors.New("URL blocked by robots.txt")
+	// ErrRobotsTxtFetchFailed is the error type for robots.txt fetch failures
+	ErrRobotsTxtFetchFailed = errors.New("robots.txt fetch failed")
 	// ErrNoCookieJar is the error type for missing cookie jar
 	ErrNoCookieJar = errors.New("Cookie jar is not available")
 	// ErrNoPattern is the error type for LimitRules without patterns
@@ -676,6 +678,23 @@ func (c *Collector) scrape(u, method string, depth int, requestData io.Reader, c
 	req = req.WithContext(context.WithValue(c.Context, CheckRevisitKey, checkRevisit))
 
 	if err := c.requestCheck(parsedURL, method, req.GetBody, depth, checkRevisit); err != nil {
+		if errors.Is(err, ErrRobotsTxtFetchFailed) {
+			if ctx == nil {
+				ctx = NewContext()
+			}
+			request := &Request{
+				URL:       req.URL,
+				Headers:   &req.Header,
+				Host:      req.Host,
+				Ctx:       ctx,
+				Depth:     depth,
+				Method:    method,
+				Body:      requestData,
+				collector: c,
+				ID:        c.requestCount.Add(1),
+			}
+			return c.handleOnError(nil, err, request, ctx)
+		}
 		return err
 	}
 	u = parsedURL.String()
@@ -876,13 +895,13 @@ func (c *Collector) checkRobots(u *url.URL) error {
 
 		resp, err := c.backend.Client.Do(req)
 		if err != nil {
-			return err
+			return fmt.Errorf("%w: %w", ErrRobotsTxtFetchFailed, err)
 		}
 		defer resp.Body.Close()
 
 		robot, err = robotstxt.FromResponse(resp)
 		if err != nil {
-			return err
+			return fmt.Errorf("%w: %w", ErrRobotsTxtFetchFailed, err)
 		}
 		c.lock.Lock()
 		c.robotsMap[u.Host] = robot

--- a/colly_test.go
+++ b/colly_test.go
@@ -1285,6 +1285,43 @@ func TestRobotsWhenDisallowedWithQueryParameter(t *testing.T) {
 	}
 }
 
+func TestRobotsFetchErrorCallsOnError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("plain HTTP server should not receive successful HTTPS request for %s", r.URL.Path)
+	}))
+	defer ts.Close()
+
+	c := NewCollector()
+	c.IgnoreRobotsTxt = false
+
+	var onErrorCalled bool
+	var onErrorRequestURL string
+	c.OnError(func(resp *Response, err error) {
+		onErrorCalled = true
+		if err == nil {
+			t.Error("OnError got nil error")
+		}
+		if resp != nil && resp.Request != nil && resp.Request.URL != nil {
+			onErrorRequestURL = resp.Request.URL.String()
+		}
+	})
+
+	targetURL := strings.Replace(ts.URL, "http://", "https://", 1) + "/target"
+	err := c.Visit(targetURL)
+	if err == nil {
+		t.Fatal("Visit error got nil, expected robots.txt fetch error")
+	}
+	if !errors.Is(err, ErrRobotsTxtFetchFailed) {
+		t.Errorf("Visit error got %#v, expected ErrRobotsTxtFetchFailed", err)
+	}
+	if !onErrorCalled {
+		t.Fatal("OnError was not called for robots.txt fetch error")
+	}
+	if onErrorRequestURL != targetURL {
+		t.Errorf("OnError request URL got %q, expected %q", onErrorRequestURL, targetURL)
+	}
+}
+
 func TestIgnoreRobotsWhenDisallowed(t *testing.T) {
 	ts := newTestServer()
 	defer ts.Close()


### PR DESCRIPTION
Fixes #741.

When `IgnoreRobotsTxt` is false, the robots.txt request runs during `requestCheck`, before the normal fetch error path has a `Request` to pass to `OnError`. A failed robots.txt fetch returned directly from `Visit`, so callers could not handle it in the same callback they use for target request failures.

This wraps robots.txt fetch/parsing failures as `ErrRobotsTxtFetchFailed` and routes only that preflight error through `OnError` with the original request URL. `ErrRobotsTxtBlocked` keeps the existing behavior.

Verification:
- `go test . -run 'TestRobots|TestIgnoreRobots|TestRobotsFetchErrorCallsOnError' -count=1 -v`
- `go test ./... -count=1`
- `git diff --check`