### PR TITLE
fix: correct instagram example struct tag

### DIFF
--- a/_examples/instagram/instagram.go
+++ b/_examples/instagram/instagram.go
@@ -44,7 +44,7 @@ type mainPageData struct {
 									Width  int `json:"width"`
 									Height int `json:"height"`
 								} `json:"dimensions"`
-							} `json:node"`
+							} `json:"node"`
 						} `json:"edges"`
 						PageInfo pageInfo `json:"page_info"`
 					} `json:"edge_owner_to_timeline_media"`


### PR DESCRIPTION
Fixes #573.

This corrects the malformed struct tag in the Instagram example from `json:node"` to `json:"node"`.

I checked current `master` before the change, and `go vet ./_examples/instagram` reports:

```text
_examples\instagram\instagram.go:38:8: struct field tag `json:node"` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
```

Verification after the fix:

```text
gofmt -l _examples/instagram/instagram.go
go vet ./_examples/instagram
go test ./_examples/instagram -run '^$'
go test ./... -count=1
git diff --check origin/master...HEAD
```
