### PR TITLE
fix(context): avoid Context.Clone deadlock under a concurrent writer

### DIFF
--- a/context.go
+++ b/context.go
@@ -90,10 +90,13 @@ func (c *Context) ForEach(fn func(k string, v interface{}) interface{}) []interf
 func (c *Context) Clone() *Context {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
+	// Iterate c.contextMap directly instead of via ForEach. ForEach takes
+	// c.lock.RLock again, which deadlocks once a writer is queued between
+	// the two RLock calls — sync.RWMutex deliberately starves additional
+	// readers while a writer is waiting to prevent writer starvation.
 	newCtx := NewContext()
-	c.ForEach(func(key string, value interface{}) interface{} {
-		newCtx.Put(key, value)
-		return nil
-	})
+	for k, v := range c.contextMap {
+		newCtx.contextMap[k] = v
+	}
 	return newCtx
 }

--- a/context_test.go
+++ b/context_test.go
@@ -16,7 +16,9 @@ package colly
 
 import (
 	"strconv"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestContextIteration(t *testing.T) {
@@ -56,5 +58,47 @@ func TestContextClone(t *testing.T) {
 		if v != ctx.GetAny(strconv.Itoa(v)).(int) {
 			t.Fatal("value not equal")
 		}
+	}
+}
+
+// TestContextCloneConcurrentWriter exercises Context.Clone while another
+// goroutine continuously writes to the same Context. The previous
+// implementation called c.ForEach inside its own RLock, taking a second
+// RLock on the same mutex; once a writer was queued between those two
+// RLock calls, sync.RWMutex starved the second RLock to prevent writer
+// starvation, deadlocking Clone. The test fails by timing out.
+func TestContextCloneConcurrentWriter(t *testing.T) {
+	ctx := NewContext()
+	for i := 0; i < 100; i++ {
+		ctx.Put(strconv.Itoa(i), i)
+	}
+
+	const iterations = 500
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			clone := ctx.Clone()
+			if got := len(clone.ForEach(func(string, interface{}) interface{} { return nil })); got < 100 {
+				t.Errorf("clone lost entries: got %d, want >=100", got)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			ctx.Put("writer", i)
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Context.Clone deadlocked under a concurrent writer")
 	}
 }


### PR DESCRIPTION
Context.Clone held c.lock.RLock and then called c.ForEach, which
acquires c.lock.RLock a second time on the same goroutine. sync.RWMutex
intentionally starves additional readers once a writer is queued (to
prevent writer starvation), so the second RLock could block forever,
deadlocking Clone whenever any other goroutine had a Put queued
between the two RLock calls.

Iterate c.contextMap directly under the single RLock instead, copying
each entry into the freshly constructed (uncontended) new context. No
behavior change for callers; the lock acquisition count drops from
two to one.

Add TestContextCloneConcurrentWriter, which fires 500 Clone calls and
500 Put calls in parallel under a 5s deadline. The test reliably
times out on the previous implementation and completes in tens of
milliseconds with the fix.