### PR TITLE
Fix nil pointer dereference in Collector.handleOnError

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -1316,17 +1316,17 @@ func (c *Collector) handleOnXML(resp *Response) error {
 }
 
 func (c *Collector) handleOnError(response *Response, err error, request *Request, ctx *Context) error {
-	if err == nil && (c.ParseHTTPErrorResponse || response.StatusCode < 203) {
-		return nil
-	}
-	if err == nil && response.StatusCode >= 203 {
-		err = errors.New(http.StatusText(response.StatusCode))
-	}
 	if response == nil {
 		response = &Response{
 			Request: request,
 			Ctx:     ctx,
 		}
+	}
+	if err == nil && (c.ParseHTTPErrorResponse || response.StatusCode < 203) {
+		return nil
+	}
+	if err == nil && response.StatusCode >= 203 {
+		err = errors.New(http.StatusText(response.StatusCode))
 	}
 	if c.debugger != nil {
 		c.debugger.Event(createEvent("error", request.ID, c.ID, map[string]string{

--- a/colly_test.go
+++ b/colly_test.go
@@ -2236,3 +2236,98 @@ func TestLimitRuleClone(t *testing.T) {
 		t.Error("clone.Init() must not mutate the source's unexported state")
 	}
 }
+
+// TestHandleOnErrorNilResponse verifies that handleOnError does not panic
+// when the response is nil. A backend may legitimately return (nil, err) on
+// transport failures (DNS lookup error, connection refused, context
+// cancellation), and may also return (nil, nil) in edge cases such as a
+// CheckResponseHeadersFunc aborting the request. Both must be handled
+// without dereferencing the nil response.
+func TestHandleOnErrorNilResponse(t *testing.T) {
+	reqURL, err := url.Parse("http://example.invalid/")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+
+	transportErr := errors.New("dial tcp: lookup example.invalid: no such host")
+
+	cases := []struct {
+		name           string
+		err            error
+		wantCallback   bool
+		wantReturnsErr bool
+	}{
+		{
+			name:           "nil response with transport error",
+			err:            transportErr,
+			wantCallback:   true,
+			wantReturnsErr: true,
+		},
+		{
+			// The original handleOnError dereferenced response.StatusCode
+			// before checking response == nil. Short-circuit evaluation
+			// hid the panic when err was non-nil, but err == nil with a
+			// nil response (the path the nil-guard was clearly written
+			// to defend against) panicked.
+			name:           "nil response with nil error",
+			err:            nil,
+			wantCallback:   false,
+			wantReturnsErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := NewCollector()
+			ctx := NewContext()
+			request := &Request{URL: reqURL, Method: "GET", Ctx: ctx}
+
+			var gotResp *Response
+			var gotErr error
+			callbackCalled := false
+			c.OnError(func(r *Response, e error) {
+				callbackCalled = true
+				gotResp = r
+				gotErr = e
+			})
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("handleOnError panicked on nil response: %v", r)
+				}
+			}()
+
+			returned := c.handleOnError(nil, tc.err, request, ctx)
+
+			if tc.wantReturnsErr {
+				if returned == nil {
+					t.Fatal("expected handleOnError to return a non-nil error")
+				}
+				if tc.err != nil && returned.Error() != tc.err.Error() {
+					t.Errorf("expected returned err %q, got %q", tc.err, returned)
+				}
+			} else if returned != nil {
+				t.Errorf("expected handleOnError to return nil, got %v", returned)
+			}
+
+			if callbackCalled != tc.wantCallback {
+				t.Errorf("OnError callback invoked=%v, want %v", callbackCalled, tc.wantCallback)
+			}
+
+			if tc.wantCallback {
+				if gotResp == nil {
+					t.Fatal("OnError callback received nil response; expected a synthesized Response")
+				}
+				if gotResp.Request != request {
+					t.Error("synthesized Response.Request should be set to the original request")
+				}
+				if gotResp.Ctx != ctx {
+					t.Error("synthesized Response.Ctx should be set to the original context")
+				}
+				if gotErr == nil || gotErr.Error() != tc.err.Error() {
+					t.Errorf("OnError callback received unexpected err: %v", gotErr)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`Collector.handleOnError` dereferenced `response.StatusCode` before
the nil-guard that synthesized a fallback `Response`. Short-circuit
evaluation of `err == nil && ...` masked the bug whenever `err` was
non-nil, but the `err == nil && response == nil` path — the exact
case the existing nil-guard was clearly written to defend against —
panicked with `runtime error: invalid memory address or nil pointer
dereference`.

This MR reorders the function so the nil-guard runs first, ensuring
every subsequent field access (including the debugger event that
reads `response.StatusCode`) operates on a valid `Response`.

## Changes

- `colly.go`: move the `response == nil` check to the top of
  `handleOnError`, before any `response.StatusCode` access.
- `colly_test.go`: add `TestHandleOnErrorNilResponse` with two
  subtests:
  - `nil response with transport error` — `(nil, err)` returned by
    the backend on DNS/connection failures.
  - `nil response with nil error` — reproduces the original panic;
    fails on `master`, passes with this fix.

## Test plan

- [x] `go test -run TestHandleOnErrorNilResponse -v .` passes.
- [x] `go test ./...` — full suite green.
- [x] Verified the new test panics without the fix (stashed
      `colly.go`, re-ran, observed
      `runtime error: invalid memory address or nil pointer dereference`).

## Risk

Low. The reordering is behavior-preserving for all paths that
previously did not panic: when `response != nil`, the new code takes
the same branches as before. The only behavioral change is that
calls with `response == nil` no longer crash and instead proceed
with the synthesized `Response` the original author had already
prepared.

## Backward compatibility

No API changes. No exported signatures modified.