### PR TITLE
Preserve Host when unmarshaling a request

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -628,6 +628,7 @@ func (c *Collector) UnmarshalRequest(r []byte) (*Request, error) {
 		Ctx:       ctx,
 		ID:        c.requestCount.Add(1),
 		Headers:   &req.Headers,
+		Host:      req.Host,
 		collector: c,
 	}, nil
 }

--- a/colly_test.go
+++ b/colly_test.go
@@ -2236,3 +2236,27 @@ func TestLimitRuleClone(t *testing.T) {
 		t.Error("clone.Init() must not mutate the source's unexported state")
 	}
 }
+
+func TestRequestMarshalRoundtripHost(t *testing.T) {
+	c := NewCollector()
+	u, _ := url.Parse("http://example.com/foo")
+	req := &Request{
+		Method:    "GET",
+		URL:       u,
+		Host:      "vhost.example.com",
+		Ctx:       NewContext(),
+		Headers:   &http.Header{},
+		collector: c,
+	}
+	data, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	got, err := c.UnmarshalRequest(data)
+	if err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if got.Host != "vhost.example.com" {
+		t.Errorf("Host not preserved: got %q want %q", got.Host, "vhost.example.com")
+	}
+}


### PR DESCRIPTION
`Request.Marshal` serializes the `Host` field (`serializableRequest.Host`), but `Collector.UnmarshalRequest` never copies it back into the returned `Request`. Any request with a custom virtual host loses it on a Marshal/Unmarshal round-trip, which is what persistent queues do, so the request is then sent to the wrong vhost.

Fix copies `req.Host` into the rebuilt `Request`, matching the other serialized fields.

To reproduce: build a `Request` with `Host` set, `Marshal()` it, `UnmarshalRequest()` it, and observe `Host` is empty. Added `TestRequestMarshalRoundtripHost` covering this; it fails without the change and passes with it. Full root package tests and `go vet` pass.