### PR TITLE
Add BBC headline scraping example

### DIFF
--- a/_examples/bbc/bbc.go
+++ b/_examples/bbc/bbc.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/gocolly/colly/v2"
+)
+
+func main() {
+	c := colly.NewCollector(
+		colly.UserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"),
+	)
+	c.OnRequest(func(r *colly.Request) {
+		fmt.Println("visiting", r.URL)
+	})
+	c.OnHTML("h3", func(e *colly.HTMLElement) {
+		title := e.Text
+		fmt.Println("title", title)
+	})
+
+
+	c.OnError(func(r *colly.Response, err error) {
+		fmt.Println("error:", err)
+		fmt.Println("status:", r.StatusCode)
+		fmt.Println("body:", string(r.Body))
+	})
+	c.Visit("https://www.bbc.com/")
+
+}


### PR DESCRIPTION
This PR adds a simple example demonstrating how to use Colly to visit a website, set a custom User-Agent, handle requests/errors, and extract text from matching HTML elements.

The example currently visits the BBC homepage and prints the text from `h3` elements and that will print all headline for the BBC headline news, which can help new users understand the basic Colly workflow:

* creating a new collector
* setting a User-Agent
* using `OnRequest`
* using `OnHTML`
* handling errors with `OnError`
* starting the scraper with `Visit`

I’m happy to adjust the example if there is a preferred target website, selector, or structure for examples in this project.
