### PR TITLE
Avoid recursive read lock in Context.Clone

### DIFF
--- a/context.go
+++ b/context.go
@@ -91,9 +91,8 @@ func (c *Context) Clone() *Context {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	newCtx := NewContext()
-	c.ForEach(func(key string, value interface{}) interface{} {
-		newCtx.Put(key, value)
-		return nil
-	})
+	for k, v := range c.contextMap {
+		newCtx.contextMap[k] = v
+	}
 	return newCtx
 }

--- a/context_test.go
+++ b/context_test.go
@@ -16,7 +16,9 @@ package colly
 
 import (
 	"strconv"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestContextIteration(t *testing.T) {
@@ -35,6 +37,52 @@ func TestContextIteration(t *testing.T) {
 		if v != ctx.GetAny(strconv.Itoa(v)).(int) {
 			t.Fatal("value not equal")
 		}
+	}
+}
+
+func TestContextCloneConcurrentWrite(t *testing.T) {
+	ctx := NewContext()
+	for i := 0; i < 50; i++ {
+		ctx.Put(strconv.Itoa(i), i)
+	}
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					ctx.Put("x", 1)
+				}
+			}
+		}()
+	}
+	for c := 0; c < 8; c++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_ = ctx.Clone()
+				}
+			}
+		}()
+	}
+	time.Sleep(time.Second)
+	close(done)
+	finished := make(chan struct{})
+	go func() { wg.Wait(); close(finished) }()
+	select {
+	case <-finished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Clone deadlocked on recursive read lock")
 	}
 }
 


### PR DESCRIPTION
`Context.Clone` acquires `c.lock.RLock()` and then calls `c.ForEach`, which acquires `c.lock.RLock()` a second time. Go's `sync.RWMutex` does not allow recursive read locks: per the docs, if a goroutine holds a read lock and another goroutine calls `Lock`, no goroutine can acquire a read lock until the first is released. So a `Context.Put` (write lock) queued between Clone's two read-lock acquisitions blocks the second `RLock` and the context deadlocks. This is reachable in normal use, since `Clone` runs while callbacks/extensions and async collectors concurrently `Put` into the context.

The fix copies the map directly under the single read lock instead of calling `ForEach`. The destination context is freshly created and not yet shared, so it needs no locking.

Added `TestContextCloneConcurrentWrite` (concurrent cloners and writers); it deadlocks on the current code and passes with the change. Full package passes, including under `-race`.