### PR TITLE
do not treat 2xx responses as errors

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -1317,10 +1317,10 @@ func (c *Collector) handleOnXML(resp *Response) error {
 }
 
 func (c *Collector) handleOnError(response *Response, err error, request *Request, ctx *Context) error {
-	if err == nil && (c.ParseHTTPErrorResponse || response.StatusCode < 203) {
+	if err == nil && (c.ParseHTTPErrorResponse || response.StatusCode < 300) {
 		return nil
 	}
-	if err == nil && response.StatusCode >= 203 {
+	if err == nil && response.StatusCode >= 300 {
 		err = errors.New(http.StatusText(response.StatusCode))
 	}
 	if response == nil {

--- a/colly_test.go
+++ b/colly_test.go
@@ -180,6 +180,10 @@ func newUnstartedTestServer() *httptest.Server {
 		w.Write([]byte("<p>error</p>"))
 	})
 
+	mux.HandleFunc("/no_content", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(204)
+	})
+
 	mux.HandleFunc("/user_agent", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Write([]byte(r.Header.Get("User-Agent")))
@@ -586,6 +590,35 @@ func TestCollectorVisit(t *testing.T) {
 
 	if !onScrapedCalled {
 		t.Error("Failed to call OnScraped callback")
+	}
+}
+
+func TestCollectorVisitNoContent(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	c := NewCollector()
+
+	onResponseCalled := false
+	onErrorCalled := false
+
+	c.OnResponse(func(r *Response) {
+		onResponseCalled = true
+		if r.StatusCode != 204 {
+			t.Errorf("Wrong response code: %d", r.StatusCode)
+		}
+	})
+	c.OnError(func(r *Response, err error) {
+		onErrorCalled = true
+	})
+
+	c.Visit(ts.URL + "/no_content")
+
+	if onErrorCalled {
+		t.Error("OnError called for 204 No Content response")
+	}
+	if !onResponseCalled {
+		t.Error("OnResponse not called for 204 No Content response")
 	}
 }
 


### PR DESCRIPTION
`handleOnError` uses `203` as the success/error boundary:

```go
if err == nil && (c.ParseHTTPErrorResponse || response.StatusCode < 203) {
    return nil
}
if err == nil && response.StatusCode >= 203 {
    err = errors.New(http.StatusText(response.StatusCode))
}
```

So any 2xx status from 203 upward (e.g. `204 No Content`, `206 Partial Content`) is treated as an error: `OnError` fires and `OnResponse` does not. 203 is itself a success code. The boundary should be 300 so the whole 2xx range is success.

Added `TestCollectorVisitNoContent` (a 204 response calls `OnResponse`, not `OnError`); it fails on the current code and passes with the change. Full package tests pass.