### PR TITLE
fix(xmlelement): resolve namespaced XML attributes by prefix

### DIFF
--- a/xmlelement.go
+++ b/xmlelement.go
@@ -67,6 +67,15 @@ func NewXMLElementFromXMLNode(resp *Response, s *xmlquery.Node) *XMLElement {
 	}
 }
 
+// xmlAttrName returns an xmlquery attribute's name as "prefix:local" when it is
+// namespaced, or its local name when it is not.
+func xmlAttrName(a xmlquery.Attr) string {
+	if a.Name.Space != "" {
+		return a.Name.Space + ":" + a.Name.Local
+	}
+	return a.Name.Local
+}
+
 // Attr returns the selected attribute of a HTMLElement or empty string
 // if no attribute found
 func (h *XMLElement) Attr(k string) string {
@@ -77,7 +86,17 @@ func (h *XMLElement) Attr(k string) string {
 			}
 		}
 	} else {
-		for _, a := range h.attributes.([]xmlquery.Attr) {
+		attrs := h.attributes.([]xmlquery.Attr)
+		// Prefer an exact match on the full "prefix:local" name so a namespaced
+		// attribute can be requested and is not confused with an unprefixed one
+		// sharing its local name.
+		for _, a := range attrs {
+			if xmlAttrName(a) == k {
+				return a.Value
+			}
+		}
+		// Fall back to the bare local name for backward compatibility.
+		for _, a := range attrs {
 			if a.Name.Local == k {
 				return a.Value
 			}
@@ -120,6 +139,11 @@ func (h *XMLElement) ChildAttr(xpathQuery, attrName string) string {
 		child := xmlquery.FindOne(h.DOM.(*xmlquery.Node), xpathQuery)
 		if child != nil {
 			for _, attr := range child.Attr {
+				if xmlAttrName(attr) == attrName {
+					return strings.TrimSpace(attr.Value)
+				}
+			}
+			for _, attr := range child.Attr {
 				if attr.Name.Local == attrName {
 					return strings.TrimSpace(attr.Value)
 				}
@@ -145,7 +169,7 @@ func (h *XMLElement) ChildAttrs(xpathQuery, attrName string) []string {
 	} else {
 		xmlquery.FindEach(h.DOM.(*xmlquery.Node), xpathQuery, func(i int, child *xmlquery.Node) {
 			for _, attr := range child.Attr {
-				if attr.Name.Local == attrName {
+				if xmlAttrName(attr) == attrName || attr.Name.Local == attrName {
 					res = append(res, strings.TrimSpace(attr.Value))
 				}
 			}

--- a/xmlelement_test.go
+++ b/xmlelement_test.go
@@ -16,6 +16,7 @@ package colly_test
 
 import (
 	"github.com/antchfx/htmlquery"
+	"github.com/antchfx/xmlquery"
 	"github.com/gocolly/colly/v2"
 	"reflect"
 	"strings"
@@ -119,5 +120,31 @@ func TestChildAttrs(t *testing.T) {
 		if !(attr == "list-item-1" || attr == "list-item-2") {
 			t.Fatalf("failed child attributes values test: %s != list-item-(1 or 2)", attr)
 		}
+	}
+}
+
+const xmlNamespacePage = `<root xmlns:ns="urn:example"><item ns:id="42" id="local">text</item></root>`
+
+func TestXMLNamespacedAttr(t *testing.T) {
+	resp := &colly.Response{StatusCode: 200, Body: []byte(xmlNamespacePage)}
+	doc, err := xmlquery.Parse(strings.NewReader(xmlNamespacePage))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	item := colly.NewXMLElementFromXMLNode(resp, xmlquery.FindOne(doc, "//item"))
+	if got := item.Attr("id"); got != "local" {
+		t.Fatalf(`Attr("id") = %q, want "local"`, got)
+	}
+	if got := item.Attr("ns:id"); got != "42" {
+		t.Fatalf(`Attr("ns:id") = %q, want "42"`, got)
+	}
+
+	root := colly.NewXMLElementFromXMLNode(resp, xmlquery.FindOne(doc, "/root"))
+	if got := root.ChildAttr("//item", "id"); got != "local" {
+		t.Fatalf(`ChildAttr("//item", "id") = %q, want "local"`, got)
+	}
+	if got := root.ChildAttr("//item", "ns:id"); got != "42" {
+		t.Fatalf(`ChildAttr("//item", "ns:id") = %q, want "42"`, got)
 	}
 }


### PR DESCRIPTION
Fixes #897.

`XMLElement.Attr`, `ChildAttr` and `ChildAttrs` matched `xmlquery` attributes only on `Name.Local`, ignoring the namespace. With both a namespaced and an unprefixed attribute sharing a local name (for example `ns:id` and `id`), a bare lookup could return the namespaced value, and a prefixed attribute could not be requested at all.

This matches the full `prefix:local` name first and falls back to the bare local name, so existing lookups of unprefixed attributes are unchanged.

```
Attr("id")    => "local"  (was "42")
Attr("ns:id") => "42"     (was "")
```

Added `TestXMLNamespacedAttr`, which fails on the previous code and passes with the fix. Existing attribute tests still pass.