### PR TITLE
fix(charset): honor BOM and <meta> charset in detection

### DIFF
--- a/colly_test.go
+++ b/colly_test.go
@@ -753,6 +753,46 @@ func TestCollectorContentSniffing(t *testing.T) {
 	}
 }
 
+func TestCollectorDetectCharsetFromMeta(t *testing.T) {
+	// Body is encoded in windows-1251 and declares its charset only via a
+	// <meta http-equiv> tag. The HTTP Content-Type header has no charset, so
+	// detection must honor the <meta> declaration. "Прометей" in
+	// windows-1251 is the byte sequence below.
+	cyrillic := []byte{0xCF, 0xF0, 0xEE, 0xEC, 0xE5, 0xF2, 0xE5, 0xE9} // Прометей
+	body := []byte(`<!DOCTYPE html>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=windows-1251">
+<title>`)
+	body = append(body, cyrillic...)
+	body = append(body, []byte(`</title></head><body>`)...)
+	body = append(body, cyrillic...)
+	body = append(body, []byte(`</body></html>`)...)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		w.Write(body)
+	}))
+	defer ts.Close()
+
+	c := NewCollector(DetectCharset())
+
+	called := false
+	c.OnResponse(func(r *Response) {
+		called = true
+		if !strings.Contains(string(r.Body), "Прометей") {
+			t.Errorf("decoded body does not contain expected Cyrillic text, got: %q", string(r.Body))
+		}
+	})
+
+	if err := c.Visit(ts.URL); err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("OnResponse was not called")
+	}
+}
+
 func TestCollectorURLRevisit(t *testing.T) {
 	ts := newTestServer()
 	defer ts.Close()

--- a/response.go
+++ b/response.go
@@ -89,12 +89,20 @@ func (r *Response) fixCharset(detectCharset bool, defaultEncoding string) error 
 		if !detectCharset {
 			return nil
 		}
-		d := chardet.NewTextDetector()
-		r, err := d.DetectBest(r.Body)
-		if err != nil {
-			return err
+		// DetermineEncoding inspects the BOM, then the HTML <meta> charset
+		// declaration, and finally falls back to statistical detection. This
+		// is more reliable than chardet alone, which ignores the BOM and the
+		// <meta> tag and mislabels single-byte encodings.
+		_, name, _ := charset.DetermineEncoding(r.Body, contentType)
+		if name == "" {
+			d := chardet.NewTextDetector()
+			r, err := d.DetectBest(r.Body)
+			if err != nil {
+				return err
+			}
+			name = r.Charset
 		}
-		contentType = "text/plain; charset=" + r.Charset
+		contentType = "text/plain; charset=" + name
 	}
 	if strings.Contains(contentType, "utf-8") || strings.Contains(contentType, "utf8") {
 		return nil


### PR DESCRIPTION
Fixes #777

When the HTTP `Content-Type` header carries no `charset`, colly relied solely on `chardet` to detect the encoding. `chardet` ignores both the byte-order mark and the HTML `<meta charset>` declaration, and frequently mislabels single-byte encodings (e.g. returning ISO-8859-1 for windows-1251), producing mojibake.

This change first calls `charset.DetermineEncoding` (from `golang.org/x/net/html/charset`, already imported), which inspects the BOM, then the `<meta>` charset, then performs statistical detection. If it returns an empty name, the original `chardet` path is used as a fallback.

A regression test serves a windows-1251 body whose charset is declared only via a `<meta http-equiv>` tag with a header Content-Type of `text/html` (no charset), and asserts the decoded body contains the expected Cyrillic text. It fails on master and passes with this fix.