### PR TITLE
fix(domain): strip trailing dot before domain filtering

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -835,6 +835,11 @@ func (c *Collector) checkFilters(URL, domain string) error {
 }
 
 func (c *Collector) isDomainAllowed(domain string) bool {
+	// A trailing-dot FQDN (e.g. "example.com.") refers to the same host as
+	// "example.com" but would not be string-equal to a configured domain,
+	// letting it bypass DisallowedDomains and be wrongly blocked by
+	// AllowedDomains.
+	domain = strings.TrimSuffix(domain, ".")
 	if slices.Contains(c.DisallowedDomains, domain) {
 		return false
 	}

--- a/colly_test.go
+++ b/colly_test.go
@@ -659,6 +659,43 @@ func TestCollectorVisitWithDisallowedDomains(t *testing.T) {
 	}
 }
 
+func TestCollectorIsDomainAllowedTrailingDot(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func() *Collector
+		domain    string
+		wantAllow bool
+	}{
+		{
+			name:      "disallowed domain blocked",
+			setup:     func() *Collector { return NewCollector(DisallowedDomains("example.com")) },
+			domain:    "example.com",
+			wantAllow: false,
+		},
+		{
+			name:      "disallowed domain blocked with trailing dot",
+			setup:     func() *Collector { return NewCollector(DisallowedDomains("example.com")) },
+			domain:    "example.com.",
+			wantAllow: false,
+		},
+		{
+			name:      "allowed domain permitted with trailing dot",
+			setup:     func() *Collector { return NewCollector(AllowedDomains("example.com")) },
+			domain:    "example.com.",
+			wantAllow: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := tt.setup()
+			if got := c.isDomainAllowed(tt.domain); got != tt.wantAllow {
+				t.Errorf("isDomainAllowed(%q) = %v, want %v", tt.domain, got, tt.wantAllow)
+			}
+		})
+	}
+}
+
 func TestCollectorVisitResponseHeaders(t *testing.T) {
 	ts := newTestServer()
 	defer ts.Close()


### PR DESCRIPTION
Fixes #900

A trailing-dot FQDN such as `example.com.` refers to the same host as `example.com` but was not string-equal to a configured domain. As a result it bypassed `DisallowedDomains` and was wrongly blocked by `AllowedDomains`.

This trims the trailing dot at the top of `isDomainAllowed`. Added a table-driven regression test asserting that `DisallowedDomains("example.com")` blocks both `example.com` and `example.com.`, and that `AllowedDomains("example.com")` allows `example.com.`. It fails on master and passes with the fix.