### PR TITLE
fix(robots): preserve query string order in robots.txt matching

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -897,7 +897,11 @@ func (c *Collector) checkRobots(u *url.URL) error {
 
 	eu := u.EscapedPath()
 	if u.RawQuery != "" {
-		eu += "?" + u.Query().Encode()
+		// robots.txt path matching treats the path+query as an ordered,
+		// opaque string. u.Query().Encode() alphabetically re-sorts the
+		// query keys, which can prevent Disallow rules that include a query
+		// string from matching. Use the on-wire query verbatim instead.
+		eu += "?" + u.RawQuery
 	}
 	if !uaGroup.Test(eu) {
 		return ErrRobotsTxtBlocked

--- a/colly_test.go
+++ b/colly_test.go
@@ -1318,6 +1318,34 @@ func TestRobotsWhenDisallowedWithQueryParameter(t *testing.T) {
 	}
 }
 
+func TestRobotsQueryStringOrderPreserved(t *testing.T) {
+	// Disallow rule includes a query string. robots.txt path matching is an
+	// ordered, opaque-string comparison, so a URL whose query keys are in a
+	// different order than alphabetical must still match the rule. colly must
+	// not re-sort the query string before matching.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			w.Write([]byte("User-agent: *\nDisallow: /p?z=\n"))
+			return
+		}
+		w.Write([]byte("ok"))
+	}))
+	defer ts.Close()
+
+	c := NewCollector()
+	c.IgnoreRobotsTxt = false
+
+	c.OnResponse(func(resp *Response) {
+		t.Fatalf("Received response, URL should have been blocked: %d", resp.StatusCode)
+	})
+
+	// Query keys are intentionally not in alphabetical order.
+	err := c.Visit(ts.URL + "/p?z=1&a=2")
+	if err == nil || err.Error() != "URL blocked by robots.txt" {
+		t.Fatalf("expected URL to be blocked by robots.txt, got: %v", err)
+	}
+}
+
 func TestIgnoreRobotsWhenDisallowed(t *testing.T) {
 	ts := newTestServer()
 	defer ts.Close()


### PR DESCRIPTION
Fixes #902

robots.txt path matching treats the path and query as an ordered, opaque string. `checkRobots` re-encoded the query with `u.Query().Encode()`, which alphabetically sorts the keys. As a result a `Disallow` rule containing a query string (e.g. `/p?z=`) failed to match a URL with the same keys in a different on-wire order, silently bypassing the rule.

This uses `u.RawQuery` verbatim. Added a regression test serving `Disallow: /p?z=` and asserting that `/p?z=1&a=2` is blocked; it fails on master (request is served with 200) and passes with the fix.