### PR TITLE
fix(clone): give cloned collector its own redirect handler

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -1421,7 +1421,7 @@ func (c *Collector) Cookies(URL string) []*http.Cookie {
 // HTTP backend, robots.txt cache and cookie jar are shared
 // between collectors.
 func (c *Collector) Clone() *Collector {
-	return &Collector{
+	clone := &Collector{
 		AllowedDomains:         c.AllowedDomains,
 		AllowURLRevisit:        c.AllowURLRevisit,
 		CacheDir:               c.CacheDir,
@@ -1442,7 +1442,6 @@ func (c *Collector) Clone() *Collector {
 		TraceHTTP:              c.TraceHTTP,
 		Context:                c.Context,
 		store:                  c.store,
-		backend:                c.backend,
 		debugger:               c.debugger,
 		Async:                  c.Async,
 		redirectHandler:        c.redirectHandler,
@@ -1456,6 +1455,28 @@ func (c *Collector) Clone() *Collector {
 		robotsMap:              c.robotsMap,
 		wg:                     &sync.WaitGroup{},
 	}
+
+	// The clone needs its own httpBackend so that its CheckRedirect closure is
+	// bound to the clone, not the parent. Otherwise the clone's filters,
+	// AllowURLRevisit and store would be ignored when following redirects.
+	// The underlying Transport, cookie jar and limit rules remain shared, so
+	// connection pooling and cookies still behave as documented.
+	clone.backend = &httpBackend{
+		LimitRules: c.backend.LimitRules,
+		lock:       c.backend.lock,
+	}
+	if c.backend.Client != nil {
+		clone.backend.Client = &http.Client{
+			Transport: c.backend.Client.Transport,
+			Jar:       c.backend.Client.Jar,
+			Timeout:   c.backend.Client.Timeout,
+		}
+	} else {
+		clone.backend.Client = &http.Client{}
+	}
+	clone.backend.Client.CheckRedirect = clone.checkRedirectFunc()
+
+	return clone
 }
 
 func (c *Collector) checkRedirectFunc() func(req *http.Request, via []*http.Request) error {

--- a/colly_test.go
+++ b/colly_test.go
@@ -1136,6 +1136,40 @@ func TestRedirectWithDisallowedURLs(t *testing.T) {
 	c.Visit(ts.URL + "/redirect")
 }
 
+func TestCloneRedirectUsesCloneFilters(t *testing.T) {
+	var blockedReached atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/a":
+			http.Redirect(w, r, "/blocked", http.StatusFound)
+		case "/blocked":
+			blockedReached.Store(true)
+			w.Write([]byte("blocked content"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	parent := NewCollector()
+	// Parent has no filters and would happily follow the redirect.
+
+	clone := parent.Clone()
+	clone.DisallowedURLFilters = []*regexp.Regexp{regexp.MustCompile("/blocked")}
+
+	clone.OnResponse(func(r *Response) {
+		if strings.HasSuffix(r.Request.URL.Path, "/blocked") {
+			t.Error("clone followed redirect to disallowed URL")
+		}
+	})
+
+	clone.Visit(ts.URL + "/a")
+
+	if blockedReached.Load() {
+		t.Error("clone reached /blocked despite its DisallowedURLFilters")
+	}
+}
+
 func TestBaseTag(t *testing.T) {
 	ts := newTestServer()
 	defer ts.Close()


### PR DESCRIPTION
Fixes #875

`Clone` shared the parent's `httpBackend`, which holds a single `*http.Client`. That client's `CheckRedirect` closure is created in `Init` and bound to the parent collector. Consequently, when a clone followed a redirect, the redirect check ran against the **parent's** `AllowURLRevisit`, `AllowedDomains`/`DisallowedDomains`, `DisallowedURLFilters` and `store` instead of the clone's.

This gives the clone its own `httpBackend` and `http.Client` that reuse the parent's `Transport`, cookie jar, timeout and limit rules (so connection pooling and cookies still behave as documented), but rebinds `CheckRedirect` to the clone via `clone.checkRedirectFunc()`.

Regression test: parent has no filters; clone sets `DisallowedURLFilters` to block `/blocked`; server redirects `/a` -> 302 -> `/blocked`. The clone must not follow the redirect. The test fails on master (the clone reaches `/blocked`) and passes with the fix. Full suite and `-race` pass.