### PR TITLE
fix(maxrequests): reserve request slot atomically to prevent async overshoot

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -679,16 +679,28 @@ func (c *Collector) scrape(u, method string, depth int, requestData io.Reader, c
 	if err := c.requestCheck(parsedURL, method, req.GetBody, depth, checkRevisit); err != nil {
 		return err
 	}
+	// Atomically reserve a request slot at this synchronous point, before the
+	// (possibly asynchronous) fetch is dispatched. Reserving here, rather than
+	// relying on the racy Load check in requestCheck, guarantees that no more
+	// than MaxRequests requests are ever made even when many Visits run
+	// concurrently under Async mode. The reserved value also serves as the
+	// request's ID.
+	reqID := c.requestCount.Add(1)
+	if c.MaxRequests > 0 && reqID > c.MaxRequests {
+		// Undo the reservation: the slot is not used.
+		c.requestCount.Add(^uint32(0))
+		return ErrMaxRequests
+	}
 	u = parsedURL.String()
 	c.wg.Add(1)
 	if c.Async {
-		go c.fetch(u, method, depth, requestData, ctx, hdr, req)
+		go c.fetch(u, method, depth, requestData, ctx, hdr, req, reqID)
 		return nil
 	}
-	return c.fetch(u, method, depth, requestData, ctx, hdr, req)
+	return c.fetch(u, method, depth, requestData, ctx, hdr, req, reqID)
 }
 
-func (c *Collector) fetch(u, method string, depth int, requestData io.Reader, ctx *Context, hdr http.Header, req *http.Request) error {
+func (c *Collector) fetch(u, method string, depth int, requestData io.Reader, ctx *Context, hdr http.Header, req *http.Request, reqID uint32) error {
 	defer c.wg.Done()
 	if ctx == nil {
 		ctx = NewContext()
@@ -702,7 +714,7 @@ func (c *Collector) fetch(u, method string, depth int, requestData io.Reader, ct
 		Method:    method,
 		Body:      requestData,
 		collector: c,
-		ID:        c.requestCount.Add(1),
+		ID:        reqID,
 	}
 
 	if req.Header.Get("Accept") == "" {

--- a/colly_test.go
+++ b/colly_test.go
@@ -1814,6 +1814,34 @@ func TestCollectorRequests(t *testing.T) {
 	}
 }
 
+func TestCollectorRequestsAsyncOvershoot(t *testing.T) {
+	var served atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		served.Add(1)
+		w.Write([]byte("ok"))
+	}))
+	defer ts.Close()
+
+	maxRequests := uint32(5)
+	c := NewCollector(
+		MaxRequests(maxRequests),
+		AllowURLRevisit(),
+		Async(true),
+	)
+
+	// Fire many concurrent visits. Without an atomic reservation at the
+	// synchronous gate, all of them pass the MaxRequests check before any
+	// fetch increments the counter, overshooting the limit.
+	for i := 0; i < 50; i++ {
+		c.Visit(ts.URL)
+	}
+	c.Wait()
+
+	if got := served.Load(); got > int32(maxRequests) {
+		t.Errorf("served %d requests, must not exceed MaxRequests=%d", got, maxRequests)
+	}
+}
+
 func TestCollectorContext(t *testing.T) {
 	// "/slow" takes 1 second to return the response.
 	// If context does abort the transfer after 0.5 seconds as it should,


### PR DESCRIPTION
Fixes #905

`requestCheck` gated on `c.requestCount.Load() >= MaxRequests`, but `requestCount` was only incremented later inside `fetch`, which runs in a goroutine under `Async`. Many concurrent `Visit` calls therefore all passed the gate before any `fetch` incremented the counter, so the number of requests made far exceeded `MaxRequests`.

This reserves the slot with an atomic add at the synchronous dispatch point in `scrape` (before the goroutine is launched) and undoes the reservation if the limit is exceeded. The reserved value is reused as the request ID, so `fetch` no longer increments the counter itself.

Regression test fires 50 concurrent `Visit`s with `MaxRequests(5)` and `Async(true)` and asserts the server is hit no more than 5 times. On master it fails (18-38 hits observed); with the fix it passes, including under `-race -count=5`. Existing `TestCollectorRequests` and the full suite remain green.