### PR TITLE
fix(queue): reset lifecycle state when Run returns

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -100,17 +100,20 @@ func (q *Queue) AddURL(URL string) error {
 
 // AddRequest adds a new Request to the queue
 func (q *Queue) AddRequest(r *colly.Request) error {
-	q.mut.Lock()
-	waken := q.wake != nil
-	q.mut.Unlock()
-	if !waken {
-		return q.storeRequest(r)
-	}
-	err := q.storeRequest(r)
-	if err != nil {
+	if err := q.storeRequest(r); err != nil {
 		return err
 	}
-	q.wake <- struct{}{}
+	q.mut.Lock()
+	defer q.mut.Unlock()
+	if q.wake != nil {
+		// Wake the loop if it is running, but never block: the loop may
+		// have already exited (leaving wake set previously caused this
+		// send to block forever).
+		select {
+		case q.wake <- struct{}{}:
+		default:
+		}
+	}
 	return nil
 }
 
@@ -147,7 +150,14 @@ func (q *Queue) Run(c *colly.Collector) error {
 	}
 	go q.loop(c, requestc, complete, errc)
 	defer close(requestc)
-	return <-errc
+	err := <-errc
+	// Reset the lifecycle state so the queue can be run again and so that
+	// a late AddRequest does not block on a wake channel nobody reads.
+	q.mut.Lock()
+	q.wake = nil
+	q.running = false
+	q.mut.Unlock()
+	return err
 }
 
 // Stop will stop the running queue

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"fmt"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -72,6 +73,62 @@ func TestQueue(t *testing.T) {
 		t.Fatalf("wrong Queue implementation: "+
 			"items = %d, requests = %d, success = %d, failure = %d",
 			items, requests, success, failure)
+	}
+}
+
+// TestQueueRunReset verifies that after Run() returns the queue is left in a
+// reusable state: a late AddRequest must not block forever on the wake channel
+// and a second Run() must not panic with "cannot call duplicate Queue.Run".
+// Reference: https://github.com/gocolly/colly/issues/740
+func TestQueueRunReset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(serverHandler))
+	defer server.Close()
+
+	storage := &InMemoryQueueStorage{MaxSize: 100000}
+	q, err := New(2, storage)
+	if err != nil {
+		t.Fatalf("New() returned an error: %v", err)
+	}
+
+	c := colly.NewCollector(colly.AllowURLRevisit())
+
+	if err := q.AddURL(server.URL + "/delay?t=1ms"); err != nil {
+		t.Fatalf("AddURL() returned an error: %v", err)
+	}
+	if err := q.Run(c); err != nil {
+		t.Fatalf("Queue.Run() returned an error: %v", err)
+	}
+
+	// A late AddRequest after Run() returned must not block forever.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = q.AddURL(server.URL + "/delay?t=1ms")
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("AddRequest after Run() blocked for more than 2 seconds")
+	}
+
+	// A second Run() must not panic.
+	runDone := make(chan error, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				runDone <- fmt.Errorf("second Run() panicked: %v", r)
+				return
+			}
+		}()
+		runDone <- q.Run(c)
+	}()
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("second Queue.Run() did not return within 2 seconds")
 	}
 }
 


### PR DESCRIPTION
@
Fixes #740

### Problem

`Queue.Run()` left `q.wake` non-nil and `q.running` true after returning. As a result:

1. A second `Run()` panicked with `cannot call duplicate Queue.Run`.
2. Any `AddRequest` issued after `Run()` returned blocked forever on the unbuffered `q.wake` channel, because the loop that drained it had already exited (#740).

### Fix

- Reset `q.wake = nil` and `q.running = false` under `q.mut` once `Run()` finishes, so the queue is reusable and a late `AddRequest` does not target a dead wake channel.
- Make the wake send in `AddRequest` non-blocking (`select { case q.wake <- struct{}{}: default: }`) under the lock, so it can never deadlock even if the loop is mid-exit.

### Test

Added `TestQueueRunReset`: after `Run()` returns it asserts (with a 2s watchdog) that a late `AddRequest` does not block, and that a second `Run()` does not panic. The test fails on master and passes with this change.
@