### PR TITLE
fix(queue): read running under mutex in loop to avoid data race

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -165,7 +165,12 @@ func (q *Queue) loop(c *colly.Collector, requestc chan<- *colly.Request, complet
 			errc <- err
 			break
 		}
-		if size == 0 && active == 0 || !q.running {
+		// Read running under the mutex: Stop() and Run() write it while
+		// holding q.mut, so reading it unlocked here is a data race.
+		q.mut.Lock()
+		running := q.running
+		q.mut.Unlock()
+		if size == 0 && active == 0 || !running {
 			// Terminate when
 			//   1. No active requests
 			//   2. Empty queue

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -75,6 +75,39 @@ func TestQueue(t *testing.T) {
 	}
 }
 
+// TestQueueStopRace verifies that calling Stop() while Run() is processing
+// queued requests does not trigger a data race on the running field. The loop
+// previously read q.running without holding q.mut while Stop() and Run() wrote
+// it under the mutex. Run with -race to detect the regression.
+func TestQueueStopRace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(serverHandler))
+	defer server.Close()
+
+	storage := &InMemoryQueueStorage{MaxSize: 100000}
+	q, err := New(10, storage)
+	if err != nil {
+		t.Fatalf("New() returned an error: %v", err)
+	}
+
+	for i := 0; i < 5000; i++ {
+		if err := q.AddURL(server.URL + "/delay?t=1ms"); err != nil {
+			t.Fatalf("AddURL() returned an error: %v", err)
+		}
+	}
+
+	c := colly.NewCollector(colly.AllowURLRevisit())
+
+	go func() {
+		// Stop the queue while Run() is processing the backlog.
+		time.Sleep(5 * time.Millisecond)
+		q.Stop()
+	}()
+
+	if err := q.Run(c); err != nil {
+		t.Fatalf("Queue.Run() returned an error: %v", err)
+	}
+}
+
 func serverHandler(w http.ResponseWriter, req *http.Request) {
 	if !serverRoute(w, req) {
 		shutdown(w)


### PR DESCRIPTION
@
Fixes #907

### Problem

`Queue.loop()` read the `running` field without holding `q.mut`, while `Stop()` and `Run()` write it under `q.mut`. This is a data race, reported by `go test -race`:

```
WARNING: DATA RACE
Write at ... by goroutine N: queue.(*Queue).Stop()  queue/queue.go:156
Previous read at ... by goroutine M: queue.(*Queue).loop()  queue/queue.go:168
```

### Fix

Snapshot `running` under `q.mut` at the top of each loop iteration and use the local copy for the termination check.

### Test

Added `TestQueueStopRace`: queues several thousand requests, then calls `Stop()` from another goroutine while `Run()` is processing. Run with `-race` it fails on master and passes with this change. The full `go test -race ./queue/...` suite passes.
@