### PR TITLE
fix: treat negative LimitRule.RandomDelay as no delay

### DIFF
--- a/colly_test.go
+++ b/colly_test.go
@@ -2270,6 +2270,39 @@ func TestLimitRuleClone(t *testing.T) {
 	}
 }
 
+// TestLimitRuleNegativeRandomDelay verifies that a negative RandomDelay does
+// not panic. RandomDelay is an exported time.Duration that users set directly;
+// the delay path feeds it to rand.Int63n, which panics for any argument <= 0.
+// In Async mode that panic happens inside the fetch goroutine and crashes the
+// process so Wait never returns. A negative RandomDelay must be treated as no
+// random delay.
+func TestLimitRuleNegativeRandomDelay(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewCollector(Async(true))
+	if err := c.Limit(&LimitRule{DomainGlob: "*", RandomDelay: -1 * time.Second}); err != nil {
+		t.Fatalf("Limit: %v", err)
+	}
+
+	if err := c.Visit(srv.URL); err != nil {
+		t.Fatalf("Visit: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		c.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Wait() timed out: a negative RandomDelay likely panicked the fetch goroutine")
+	}
+}
+
 func TestRequestMarshalRoundtripHost(t *testing.T) {
 	c := NewCollector()
 	u, _ := url.Parse("http://example.com/foo")

--- a/http_backend.go
+++ b/http_backend.go
@@ -205,7 +205,7 @@ func (h *httpBackend) Do(request *http.Request, bodySize int, checkRequestHeader
 		r.waitChan <- true
 		defer func(r *LimitRule) {
 			randomDelay := time.Duration(0)
-			if r.RandomDelay != 0 {
+			if r.RandomDelay > 0 {
 				randomDelay = time.Duration(rand.Int63n(int64(r.RandomDelay)))
 			}
 			time.Sleep(r.Delay + randomDelay)


### PR DESCRIPTION
Fixes #910

## Problem

`LimitRule.RandomDelay` is an exported `time.Duration` that users set directly. The delay path in `http_backend.go` feeds it to `rand.Int63n`:

```go
if r.RandomDelay != 0 {
    randomDelay = time.Duration(rand.Int63n(int64(r.RandomDelay)))
}
```

`rand.Int63n` panics for any argument `<= 0`, so a negative `RandomDelay` panics with `invalid argument to Int63n`. In `Async` mode the panic happens inside the fetch goroutine and crashes the whole process, so `Wait()` never returns.

## Fix

Change the guard from `!= 0` to `> 0` so a negative `RandomDelay` is treated as no random delay. This mirrors the fact that a negative `Delay` is already a harmless no-op for `time.Sleep`.

## Test

Added `TestLimitRuleNegativeRandomDelay`, which configures a rule with `RandomDelay: -1 * time.Second`, performs an async `Visit` against an `httptest` server, and asserts `Wait()` completes without panicking. It fails (panics) on the current code and passes with the fix. Full `go test ./...` passes.