### PR TITLE
fix: preserve body and ProxyURL/ResponseCharacterEncoding in Request.Marshal round-trip

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -621,15 +621,17 @@ func (c *Collector) UnmarshalRequest(r []byte) (*Request, error) {
 	}
 
 	return &Request{
-		Method:    req.Method,
-		URL:       u,
-		Depth:     req.Depth,
-		Body:      bytes.NewReader(req.Body),
-		Ctx:       ctx,
-		ID:        c.requestCount.Add(1),
-		Headers:   &req.Headers,
-		Host:      req.Host,
-		collector: c,
+		Method:                    req.Method,
+		URL:                       u,
+		Depth:                     req.Depth,
+		Body:                      bytes.NewReader(req.Body),
+		Ctx:                       ctx,
+		ID:                        c.requestCount.Add(1),
+		Headers:                   &req.Headers,
+		Host:                      req.Host,
+		ProxyURL:                  req.ProxyURL,
+		ResponseCharacterEncoding: req.ResponseCharacterEncoding,
+		collector:                 c,
 	}, nil
 }
 

--- a/colly_test.go
+++ b/colly_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -2291,5 +2292,94 @@ func TestRequestMarshalRoundtripHost(t *testing.T) {
 	}
 	if got.Host != "vhost.example.com" {
 		t.Errorf("Host not preserved: got %q want %q", got.Host, "vhost.example.com")
+	}
+}
+
+func TestRequestMarshalIsIdempotent(t *testing.T) {
+	c := NewCollector()
+	u, _ := url.Parse("http://example.com/foo")
+	req := &Request{
+		Method:    "POST",
+		URL:       u,
+		Ctx:       NewContext(),
+		Headers:   &http.Header{},
+		Body:      bytes.NewReader([]byte("payload-body")),
+		collector: c,
+	}
+
+	first, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("first marshal failed: %v", err)
+	}
+	second, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("second marshal failed: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Errorf("Marshal is not idempotent:\nfirst:  %s\nsecond: %s", first, second)
+	}
+
+	// The original body must remain readable after Marshal.
+	if req.Body == nil {
+		t.Fatal("request body was destroyed by Marshal")
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("reading body after marshal failed: %v", err)
+	}
+	if string(body) != "payload-body" {
+		t.Errorf("body not preserved after Marshal: got %q want %q", string(body), "payload-body")
+	}
+}
+
+func TestRequestMarshalRoundtripFidelity(t *testing.T) {
+	c := NewCollector()
+	u, _ := url.Parse("http://example.com/foo")
+	ctx := NewContext()
+	ctx.Put("k", "v")
+	headers := http.Header{}
+	headers.Set("X-Test", "yes")
+	req := &Request{
+		Method:                    "POST",
+		URL:                       u,
+		Host:                      "vhost.example.com",
+		Depth:                     3,
+		Ctx:                       ctx,
+		Headers:                   &headers,
+		Body:                      bytes.NewReader([]byte("payload-body")),
+		ProxyURL:                  "http://proxy.example.com:8080",
+		ResponseCharacterEncoding: "windows-1252",
+		collector:                 c,
+	}
+
+	data, err := req.Marshal()
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	got, err := c.UnmarshalRequest(data)
+	if err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if got.ProxyURL != "http://proxy.example.com:8080" {
+		t.Errorf("ProxyURL not preserved: got %q", got.ProxyURL)
+	}
+	if got.ResponseCharacterEncoding != "windows-1252" {
+		t.Errorf("ResponseCharacterEncoding not preserved: got %q", got.ResponseCharacterEncoding)
+	}
+	if got.Method != "POST" {
+		t.Errorf("Method not preserved: got %q", got.Method)
+	}
+	if got.Depth != 3 {
+		t.Errorf("Depth not preserved: got %d", got.Depth)
+	}
+	if got.Host != "vhost.example.com" {
+		t.Errorf("Host not preserved: got %q", got.Host)
+	}
+	if got.Headers.Get("X-Test") != "yes" {
+		t.Errorf("Headers not preserved: got %q", got.Headers.Get("X-Test"))
+	}
+	if got.Ctx.Get("k") != "v" {
+		t.Errorf("Ctx not preserved: got %q", got.Ctx.Get("k"))
 	}
 }

--- a/request.go
+++ b/request.go
@@ -53,14 +53,16 @@ type Request struct {
 }
 
 type serializableRequest struct {
-	URL     string
-	Method  string
-	Depth   int
-	Body    []byte
-	ID      uint32
-	Ctx     map[string]interface{}
-	Headers http.Header
-	Host    string
+	URL                       string
+	Method                    string
+	Depth                     int
+	Body                      []byte
+	ID                        uint32
+	Ctx                       map[string]interface{}
+	Headers                   http.Header
+	Host                      string
+	ProxyURL                  string
+	ResponseCharacterEncoding string
 }
 
 // New creates a new request with the context of the original request
@@ -183,15 +185,20 @@ func (r *Request) Marshal() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Restore the body so that Marshal is idempotent and the request
+		// remains usable (e.g. for a subsequent Do/Retry or Marshal call).
+		r.Body = bytes.NewReader(body)
 	}
 	sr := &serializableRequest{
-		URL:    r.URL.String(),
-		Host:   r.Host,
-		Method: r.Method,
-		Depth:  r.Depth,
-		Body:   body,
-		ID:     r.ID,
-		Ctx:    ctx,
+		URL:                       r.URL.String(),
+		Host:                      r.Host,
+		Method:                    r.Method,
+		Depth:                     r.Depth,
+		Body:                      body,
+		ID:                        r.ID,
+		Ctx:                       ctx,
+		ProxyURL:                  r.ProxyURL,
+		ResponseCharacterEncoding: r.ResponseCharacterEncoding,
 	}
 	if r.Headers != nil {
 		sr.Headers = *r.Headers


### PR DESCRIPTION
Fixes #912.

This fixes two facets of `Request.Marshal()` round-trip fidelity, both with regression tests.

## Facet A: Marshal() drained the body (non-idempotent)

`Marshal()` read `r.Body` via `io.ReadAll` but never restored it, so the request body was destroyed by the call. A second `Marshal()`, or a later `Do()` / `Retry()`, then saw an empty body. The fix restores `r.Body = bytes.NewReader(body)` after reading.

## Facet B: ProxyURL and ResponseCharacterEncoding were dropped

`serializableRequest` omitted `ProxyURL` and `ResponseCharacterEncoding`, so `Marshal()` / `UnmarshalRequest()` silently lost them. `ResponseCharacterEncoding` is a user-set, pre-fetch field consumed by `fixCharset`; losing it on a queued/persisted request changes behavior (falls back to auto-detect). Both fields are now added to `serializableRequest`, populated in `Marshal()`, and restored in `UnmarshalRequest()`.

## Tests

- `TestRequestMarshalIsIdempotent`: two `Marshal()` calls yield identical bytes and `r.Body` is still readable afterward.
- `TestRequestMarshalRoundtripFidelity`: `Marshal` -> `UnmarshalRequest` preserves ProxyURL and ResponseCharacterEncoding (plus Method/Depth/Host/Headers/Ctx).

Both new tests fail on master and pass with this change. Full `go test ./...` is green.