### PR TITLE
fix: strip sensitive headers on cross-origin redirects

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -1509,6 +1509,23 @@ func (c *Collector) checkRedirectFunc() func(req *http.Request, via []*http.Requ
 			}
 		}
 
+		lastRequest := via[len(via)-1]
+
+		// If the destination changed (host:port comparison is intentionally
+		// strict so a same-host different-port redirect is treated as
+		// cross-origin), strip sensitive credential headers so they are not
+		// leaked to a different origin. This runs unconditionally, including
+		// when a custom redirectHandler is set, so a custom handler can never
+		// re-enable the leak. Note: arbitrary caller-supplied auth headers
+		// (e.g. X-Api-Key) cannot be stripped generically and remain the
+		// caller's responsibility.
+		if req.URL.Host != lastRequest.URL.Host {
+			req.Header.Del("Authorization")
+			req.Header.Del("Cookie")
+			req.Header.Del("Cookie2")
+			req.Header.Del("Www-Authenticate")
+		}
+
 		if c.redirectHandler != nil {
 			return c.redirectHandler(req, via)
 		}
@@ -1516,13 +1533,6 @@ func (c *Collector) checkRedirectFunc() func(req *http.Request, via []*http.Requ
 		// Honor golangs default of maximum of 10 redirects
 		if len(via) >= 10 {
 			return http.ErrUseLastResponse
-		}
-
-		lastRequest := via[len(via)-1]
-
-		// If domain has changed, remove the Authorization-header if it exists
-		if req.URL.Host != lastRequest.URL.Host {
-			req.Header.Del("Authorization")
 		}
 
 		return nil

--- a/colly_test.go
+++ b/colly_test.go
@@ -2293,3 +2293,127 @@ func TestRequestMarshalRoundtripHost(t *testing.T) {
 		t.Errorf("Host not preserved: got %q want %q", got.Host, "vhost.example.com")
 	}
 }
+
+func TestRedirectStripsSensitiveHeaders(t *testing.T) {
+	// Target server records the credential headers it receives.
+	var (
+		mu       sync.Mutex
+		gotAuth  string
+		gotCooky string
+	)
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotAuth = r.Header.Get("Authorization")
+		gotCooky = r.Header.Get("Cookie")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	// Cross-host redirector: redirects to a different host:port (the target).
+	crossHost := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer crossHost.Close()
+
+	reset := func() {
+		mu.Lock()
+		gotAuth, gotCooky = "", ""
+		mu.Unlock()
+	}
+
+	// (a) cross-host redirect must strip both Authorization and Cookie.
+	func() {
+		reset()
+		c := NewCollector()
+		c.OnRequest(func(r *Request) {
+			r.Headers.Set("Authorization", "Bearer secret")
+			r.Headers.Set("Cookie", "session=secret")
+		})
+		c.Visit(crossHost.URL)
+		mu.Lock()
+		defer mu.Unlock()
+		if gotAuth != "" {
+			t.Errorf("cross-host redirect leaked Authorization: %q", gotAuth)
+		}
+		if gotCooky != "" {
+			t.Errorf("cross-host redirect leaked Cookie: %q", gotCooky)
+		}
+	}()
+
+	// (b) same-host different-port redirect must also strip (strict host:port).
+	func() {
+		reset()
+		samePortRedir := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, target.URL, http.StatusFound)
+		}))
+		defer samePortRedir.Close()
+		c := NewCollector()
+		c.OnRequest(func(r *Request) {
+			r.Headers.Set("Authorization", "Bearer secret")
+			r.Headers.Set("Cookie", "session=secret")
+		})
+		c.Visit(samePortRedir.URL)
+		mu.Lock()
+		defer mu.Unlock()
+		if gotAuth != "" || gotCooky != "" {
+			t.Errorf("different-port redirect leaked credentials: auth=%q cookie=%q", gotAuth, gotCooky)
+		}
+	}()
+
+	// (c) custom redirectHandler installed: stripping must STILL happen.
+	func() {
+		reset()
+		c := NewCollector()
+		c.SetRedirectHandler(func(req *http.Request, via []*http.Request) error {
+			return nil
+		})
+		c.OnRequest(func(r *Request) {
+			r.Headers.Set("Authorization", "Bearer secret")
+			r.Headers.Set("Cookie", "session=secret")
+		})
+		c.Visit(crossHost.URL)
+		mu.Lock()
+		defer mu.Unlock()
+		if gotAuth != "" || gotCooky != "" {
+			t.Errorf("custom redirectHandler bypassed stripping: auth=%q cookie=%q", gotAuth, gotCooky)
+		}
+	}()
+}
+
+func TestRedirectSameOriginKeepsHeaders(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		gotAuth string
+		gotCook string
+	)
+	// Single server: redirects /from to /to on the same host:port.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/from":
+			http.Redirect(w, r, "/to", http.StatusFound)
+		case "/to":
+			mu.Lock()
+			gotAuth = r.Header.Get("Authorization")
+			gotCook = r.Header.Get("Cookie")
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	c := NewCollector()
+	c.OnRequest(func(r *Request) {
+		r.Headers.Set("Authorization", "Bearer secret")
+		r.Headers.Set("Cookie", "session=secret")
+	})
+	c.Visit(ts.URL + "/from")
+	mu.Lock()
+	defer mu.Unlock()
+	if gotAuth != "Bearer secret" {
+		t.Errorf("same-origin redirect dropped Authorization: got %q", gotAuth)
+	}
+	if gotCook != "session=secret" {
+		t.Errorf("same-origin redirect dropped Cookie: got %q", gotCook)
+	}
+}


### PR DESCRIPTION
Fixes #916

## Problem

On a cross-origin redirect colly only stripped `Authorization`, leaking user-set `Cookie` (and other credential headers) to a different host or port. Additionally, when a custom `redirectHandler` was set the handler returned before any stripping ran, bypassing the protection entirely.

## Fix

- Strip `Authorization`, `Cookie`, `Cookie2` and `Www-Authenticate` whenever the redirect target `host:port` differs from the previous request. The strict `host:port` comparison is intentionally kept (a same-host different-port redirect is treated as cross-origin).
- Run the stripping **unconditionally**, before dispatching to a custom `redirectHandler`, so a custom handler can no longer re-enable the leak.
- A code comment notes that arbitrary caller-supplied auth headers (e.g. `X-Api-Key`) cannot be stripped generically and remain the caller's responsibility.

## Tests

Added `TestRedirectStripsSensitiveHeaders` (cross-host, same-host different-port, and custom-redirectHandler cases) and `TestRedirectSameOriginKeepsHeaders` (same `host:port` redirect preserves both headers). Verified the new tests fail on master and pass with the fix; full suite is green.