### PR TITLE
fix: clear stale Content-Encoding and Content-Length after manual gzip decode

### DIFF
--- a/colly_test.go
+++ b/colly_test.go
@@ -2293,3 +2293,54 @@ func TestRequestMarshalRoundtripHost(t *testing.T) {
 		t.Errorf("Host not preserved: got %q want %q", got.Host, "vhost.example.com")
 	}
 }
+
+func TestManualGzipDecodeClearsStaleHeaders(t *testing.T) {
+	const payload = "hello gzip world"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		if _, err := gz.Write([]byte(payload)); err != nil {
+			t.Errorf("gzip write failed: %v", err)
+		}
+		gz.Close()
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", buf.Len()))
+		w.WriteHeader(http.StatusOK)
+		w.Write(buf.Bytes())
+	}))
+	defer ts.Close()
+
+	var (
+		gotBody string
+		gotResp *Response
+	)
+	c := NewCollector()
+	c.OnRequest(func(r *Request) {
+		// Force manual decode by advertising gzip ourselves; Go's transport
+		// will not transparently decompress when Accept-Encoding is set
+		// explicitly.
+		r.Headers.Set("Accept-Encoding", "gzip")
+	})
+	c.OnResponse(func(resp *Response) {
+		gotBody = string(resp.Body)
+		gotResp = resp
+	})
+	if err := c.Visit(ts.URL); err != nil {
+		t.Fatalf("visit failed: %v", err)
+	}
+
+	if gotBody != payload {
+		t.Errorf("body not decompressed: got %q want %q", gotBody, payload)
+	}
+	if gotResp == nil {
+		t.Fatal("no response captured")
+	}
+	if ce := gotResp.Headers.Get("Content-Encoding"); ce != "" {
+		t.Errorf("Content-Encoding should be cleared after manual gzip decode, got %q", ce)
+	}
+	if cl := gotResp.Headers.Get("Content-Length"); cl != "" {
+		t.Errorf("Content-Length should be cleared after manual gzip decode, got %q", cl)
+	}
+}

--- a/http_backend.go
+++ b/http_backend.go
@@ -254,6 +254,12 @@ func (h *httpBackend) Do(request *http.Request, bodySize int, checkRequestHeader
 					return nil, err
 				}
 				defer bodyReader.(*gzip.Reader).Close()
+				// We have decompressed the body manually, so the stored
+				// response headers must no longer advertise the original
+				// encoding or the compressed length. Mirror net/http's
+				// behaviour when it transparently decompresses a response.
+				res.Header.Del("Content-Encoding")
+				res.Header.Del("Content-Length")
 			}
 		default:
 			return nil, err


### PR DESCRIPTION
Fixes #918

## Problem

When colly manually gzip-decodes a response body, it left the original `Content-Encoding: gzip` and the compressed `Content-Length` on the stored `Response`. The headers then lied about the now-plaintext body, and `Content-Length` no longer matched `len(Response.Body)`. Go's transport strips both headers when it transparently decompresses, but colly's manual path did not.

## Fix

After a successful manual gzip decode, delete `Content-Encoding` and `Content-Length` from the stored response headers, mirroring net/http.

## Tests

Added `TestManualGzipDecodeClearsStaleHeaders`: an httptest server returns a gzip body with `Content-Encoding: gzip` and a compressed `Content-Length`; the request sets `Accept-Encoding: gzip` to force the manual decode path. The test asserts the body is decompressed and that both `Content-Encoding` and `Content-Length` are absent on the colly `Response`. Verified it fails on master and passes with the fix; full suite is green.