### PR TITLE
fix: escape multipart field names in PostMultipart to prevent header injection

### DIFF
--- a/colly.go
+++ b/colly.go
@@ -1580,7 +1580,7 @@ func createMultipartReader(boundary string, data map[string][]byte) io.Reader {
 	buffer.WriteString("Content-type: multipart/form-data; boundary=" + boundary + "\n\n")
 	for contentType, content := range data {
 		buffer.WriteString(dashBoundary + "\n")
-		buffer.WriteString("Content-Disposition: form-data; name=" + contentType + "\n")
+		buffer.WriteString("Content-Disposition: form-data; name=\"" + escapeMultipartFieldName(contentType) + "\"\n")
 		buffer.WriteString(fmt.Sprintf("Content-Length: %d \n\n", len(content)))
 		buffer.Write(content)
 		buffer.WriteString("\n")
@@ -1588,6 +1588,25 @@ func createMultipartReader(boundary string, data map[string][]byte) io.Reader {
 	buffer.WriteString(dashBoundary + "--\n\n")
 	return bytes.NewReader(buffer.Bytes())
 
+}
+
+// multipartFieldNameEscaper escapes a field name for use in a
+// Content-Disposition header, following RFC 7578 section 4.2:
+// backslash and double quote are backslash-escaped, and CR / LF are
+// percent-encoded so a field name cannot inject header lines.
+//
+// strings.NewReplacer operates on the raw byte sequence, preserving
+// invalid UTF-8 bytes that a range loop over the string would silently
+// replace with U+FFFD.
+var multipartFieldNameEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`"`, `\"`,
+	"\r", "%0D",
+	"\n", "%0A",
+)
+
+func escapeMultipartFieldName(s string) string {
+	return multipartFieldNameEscaper.Replace(s)
 }
 
 // randomBoundary was borrowed from

--- a/colly_test.go
+++ b/colly_test.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -2291,5 +2293,62 @@ func TestRequestMarshalRoundtripHost(t *testing.T) {
 	}
 	if got.Host != "vhost.example.com" {
 		t.Errorf("Host not preserved: got %q want %q", got.Host, "vhost.example.com")
+	}
+}
+
+func TestPostMultipartEscapesFieldNames(t *testing.T) {
+	boundary := "test-boundary"
+	data := map[string][]byte{
+		"normal":     []byte("value"),
+		"quote\"d":   []byte("v1"),
+		"back\\slash": []byte("v2"),
+		"new\r\nline": []byte("v3"),
+	}
+	raw, err := io.ReadAll(createMultipartReader(boundary, data))
+	if err != nil {
+		t.Fatalf("unexpected error reading multipart body: %v", err)
+	}
+
+	mr := multipart.NewReader(bytes.NewReader(raw), boundary)
+	// The generated body starts with a Content-type preamble line, which
+	// multipart readers are allowed to skip.
+	names := map[string]bool{}
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error parsing multipart body: %v", err)
+		}
+		names[part.FormName()] = true
+	}
+	// Go's multipart parser unescapes quoted-string values (\" -> ", \\ -> \)
+	// while percent-encoded CR/LF stays literal, per RFC 7578 §4.2.
+	for _, want := range []string{`normal`, `quote"d`, `back\slash`, "new%0D%0Aline"} {
+		if !names[want] {
+			t.Errorf("expected escaped field name %q in parsed parts, got %v", want, names)
+		}
+	}
+	// Ensure no raw header injection: the raw body must not contain the
+	// unescaped field name with a newline.
+	if bytes.Contains(raw, []byte("name=\"new\r\nline\"")) {
+		t.Errorf("raw multipart body contains unescaped newline in field name")
+	}
+}
+
+func TestEscapeMultipartFieldNamePreservesInvalidUTF8(t *testing.T) {
+	// A range loop over the string would replace these bytes with U+FFFD,
+	// silently corrupting the field name. strings.NewReplacer keeps the
+	// original bytes intact.
+	name := "bad\xff\xfe"
+	escaped := escapeMultipartFieldName(name)
+	if !strings.Contains(escaped, "\xff\xfe") {
+		t.Errorf("escapeMultipartFieldName dropped invalid UTF-8 bytes: %q", escaped)
+	}
+	// U+FFFD encodes to EF BF BD in UTF-8; check the raw bytes rather than
+	// using ContainsRune, which would itself decode the invalid bytes.
+	if bytes.Contains([]byte(escaped), []byte{0xEF, 0xBF, 0xBD}) {
+		t.Errorf("escapeMultipartFieldName replaced invalid UTF-8 with U+FFFD: %q", escaped)
 	}
 }

--- a/colly_test.go
+++ b/colly_test.go
@@ -2299,8 +2299,8 @@ func TestRequestMarshalRoundtripHost(t *testing.T) {
 func TestPostMultipartEscapesFieldNames(t *testing.T) {
 	boundary := "test-boundary"
 	data := map[string][]byte{
-		"normal":     []byte("value"),
-		"quote\"d":   []byte("v1"),
+		"normal":      []byte("value"),
+		"quote\"d":    []byte("v1"),
 		"back\\slash": []byte("v2"),
 		"new\r\nline": []byte("v3"),
 	}


### PR DESCRIPTION
## Description

Fixes #924: `PostMultipart` writes map keys directly into the `Content-Disposition` header without quoting or escaping. A field name containing CR/LF could inject arbitrary header lines into the multipart body.

## Changes

- `colly.go`: new `escapeMultipartFieldName` helper implementing RFC 7578 §4.2 escaping (quote the value, backslash-escape `\\` and `"`, percent-encode CR/LF as `%0D`/`%0A`), applied in `createMultipartReader`.
- `colly_test.go`: `TestPostMultipartEscapesFieldNames` parses the generated body with `mime/multipart` and asserts:
  - normal / quote / backslash names round-trip correctly (Go's parser unescapes quoted-strings),
  - CR/LF in a name stays percent-encoded (`new%0D%0Aline`),
  - the raw body contains no unescaped newline in a field name.

## Verification

- `go test -run TestPostMultipartEscapesFieldNames`: PASS
- `go test ./...`: all packages PASS
- Control experiment: reverting the escaping makes the new test fail with `malformed MIME header: missing colon` (the header injection the issue describes)
- `go vet .`: clean